### PR TITLE
📝 Docs: #2 Xcode 선택 에러 트러블슈팅 가이드 추가

### DIFF
--- a/docs/onboarding-guide.md
+++ b/docs/onboarding-guide.md
@@ -31,6 +31,25 @@ make tuist-generate
 
 ---
 
+### ⚠️ 위 프로젝트 생성시 아래와 같은 에러가 생기는 경우에는?
+```bash
+✖ Error 
+  Couldn't find Xcode's Info.plist at /Library/Contents/Info.plist. Make sure your Xcode installation is selected by running: sudo xcode-select -s /Applications/Xcode.app 
+
+  Sorry this didn’t work. Here’s what to try next: 
+   ▸ If the error is actionable, address it
+   ▸ If the error is not actionable, let's discuss it in the Troubleshooting & how to
+   ▸ If you are very certain it's a bug, file an issue
+   ▸ Check out the logs at /Users/shinmingyu/.local/state/tuist/logs/05629AC4-224F-422E-A896-A44FE268C3AA.log
+make: *** [tuist-generate] Error 1
+```
+
+Xcode를 관리자 권한으로 전환합니다.
+```bash
+sudo xcode-select --switch /Applications/Xcode.app
+```
+---
+
 ## 2. 브랜치 규칙
 
 ### 📌 형식


### PR DESCRIPTION
## ✨ What's this PR?
### 📌 관련 이슈 (Related Issue)
- Closes #2

---

### 🧶 주요 변경 내용 (Summary)

- 온보딩 가이드에 Xcode 경로 설정 트러블슈팅 섹션 추가
- Tuist 프로젝트 생성 시 발생하는 `Xcode's Info.plist` 경로 오류 해결 방법 문서화
- `xcode-select` 명령어를 이용한 Xcode 경로 설정 가이드 작성

---

### 📸 스크린샷 (Optional)

해당 없음 (문서 작업)

---

### 🧪 테스트 / 검증 내역

- [x] 온보딩 가이드 문서 내용 확인
- [x] 마크다운 문법 정상 렌더링 확인
- [x] 에러 메시지 및 해결 방법 정확성 검토

---

### 💬 기타 공유 사항

- Tuist 프로젝트 생성 시 자주 발생하는 이슈에 대한 문서화 작업입니다
- 신규 팀원 온보딩 과정에서 참고할 수 있도록 작성했습니다
- 실제 발생한 에러 메시지를 그대로 포함하여 검색 시 찾기 쉽도록 했습니다

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)

- 트러블슈팅 내용이 명확하고 이해하기 쉬운지 확인 부탁드립니다
- 추가로 포함되면 좋을 내용이 있다면 제안 부탁드립니다