### PR TITLE
💄 Style. 다크모드 강제 설정 추가

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -16,6 +16,7 @@ let baseInfoPlist: [String: Plist.Value] = [
     "NSLocationWhenInUseUsageDescription": "현재 위치를 기반으로 주변 정류장 정보를 제공하기 위해 위치 정보가 필요합니다.",
     "ITSAppUsesNonExemptEncryption": .boolean(false),
     "UIDesignRequiresCompatibility": .boolean(true),
+    "UIUserInterfaceStyle": "Dark",
 ]
 
 let formatScript: TargetScript = .pre(


### PR DESCRIPTION
## ✨ What's this PR?
### 📌 관련 이슈 (Related Issue)
- Closes #18

---

### 🧶 주요 변경 내용 (Summary)

**다크모드 강제 적용 설정**
- `Project.swift`의 `baseInfoPlist`에 `UIUserInterfaceStyle: "Dark"` 추가
- 앱 전체에서 시스템 설정과 무관하게 항상 다크모드로 표시

---

### 📸 스크린샷 (Optional)
<img width="1320" height="2868" alt="Simulator Screenshot - iPhone 17 Pro Max - 2025-10-20 at 14 59 37" src="https://github.com/user-attachments/assets/f1ae629d-e491-4bb7-b4b3-5d601a38ddb4" />

---

### 🧪 테스트 / 검증 내역

- [x] `mise x -- make gen` 실행하여 프로젝트 정상 생성 확인
- [x] Xcode에서 Info.plist에 Appearance: Dark 설정 반영 확인
- [x] 시뮬레이터에서 라이트 모드 설정 시에도 앱이 다크모드로 표시되는지 확인
- [x] 빌드 및 실행 정상 동작 확인

---

### 💬 기타 공유 사항

- Tuist 기반 프로젝트이므로 `Project.swift` 파일 수정만으로 모든 타겟(OffStageApp, BusAI)에 일괄 적용됩니다
- 향후 라이트 모드 지원이 필요할 경우 이 설정을 제거하거나 수정하면 됩니다
- Bundle Identifier 관련 문제가 있었으나 organizationName 수정으로 해결되었습니다

---

### 🙇🏻‍♀️ 리뷰 가이드

- `Project.swift`의 `baseInfoPlist` 설정 추가 확인
- 변경사항이 단순하므로 빠른 리뷰 가능합니다