### PR TITLE
✨ Feature: #30 HomeEdit 화면 기본 구조 및 네비게이션 구현

### DIFF
--- a/OffStageApp/Sources/Presentation/Home/HomeView.swift
+++ b/OffStageApp/Sources/Presentation/Home/HomeView.swift
@@ -191,7 +191,7 @@ struct HomeView: View {
                             .padding(.bottom)
 
                             Button("편집") {
-                                router.push(.homeedit)
+                                router.push(.homeedit(busStationData))
                             }
                         }
                     }

--- a/OffStageApp/Sources/Presentation/HomeEdit/HomeEditView.swift
+++ b/OffStageApp/Sources/Presentation/HomeEdit/HomeEditView.swift
@@ -2,26 +2,39 @@ import SwiftUI
 
 struct HomeEditView: View {
     @EnvironmentObject var router: Router<AppRoute>
+    let stations: [BusStationData]
 
     var body: some View {
-        VStack(spacing: 16) {
-            Text("홈 편집 화면")
-                .font(.largeTitle)
-
-            Button("이전 화면으로 돌아가기 (pop)") {
-                router.pop()
-            }
-
-            Button("홈으로 돌아가기 (popToRoot)") {
-                router.popToRoot()
+        VStack {
+            ScrollView {
+                ForEach(stations) { station in
+                    BusStationEditView(stationItem: station)
+                }
             }
         }
         .padding()
-        .navigationTitle("Home Edit")
+        .navigationBarBackButtonHidden(true)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button {
+                    router.pop()
+                } label: {
+                    Image(systemName: "chevron.left")
+                        .foregroundColor(.gray)
+                }
+            }
+
+            ToolbarItem(placement: .principal) {
+                Text("홈 화면 편집")
+                    .font(.title2)
+                    .foregroundColor(.white)
+            }
+        }
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarBackground(.visible, for: .navigationBar)
     }
 }
 
 #Preview {
-    // 미리보기용 Mock Router
-    RouterView(router: Router<AppRoute>(root: .homeedit))
+    HomeEditView(stations: busStationData)
 }

--- a/OffStageApp/Sources/Presentation/HomeEdit/SubView/BusStationEditView.swift
+++ b/OffStageApp/Sources/Presentation/HomeEdit/SubView/BusStationEditView.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+struct BusStationEditView: View {
+    let stationItem: BusStationData
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading) {
+                Text(stationItem.stationName)
+                    .font(.title2)
+                HStack {
+                    Text(stationItem.stationNumber)
+                        .foregroundColor(.gray)
+                    Text("(시청방면)")
+                        .foregroundColor(.gray)
+                }
+            }
+
+            Spacer()
+
+            Button {} label: { Image(systemName: "line.3.horizontal") }
+
+            Button {} label: { Image(systemName: "trash") }
+        }
+        .padding(.horizontal, 25)
+        .padding(.vertical, 30)
+        .background(.gray.opacity(0.4))
+        .cornerRadius(15)
+    }
+}
+
+#Preview {
+    BusStationEditView(stationItem: busStationData[0])
+}

--- a/OffStageApp/Sources/Presentation/Routing/AppRouter.swift
+++ b/OffStageApp/Sources/Presentation/Routing/AppRouter.swift
@@ -6,7 +6,7 @@ enum AppRoute: Routable {
     case search(busStopInfo: BusStopInfo)
     case busstation(busStopInfo: BusStopInfo)
     case busvision
-    case homeedit
+    case homeedit([BusStationData])
     case onboarding
     case test(busStopInfo: BusStopInfo)
 
@@ -25,8 +25,8 @@ enum AppRoute: Routable {
         case .busvision:
             BusVisionView()
 
-        case .homeedit:
-            HomeEditView()
+        case let .homeedit(stations):
+            HomeEditView(stations: stations)
 
         case .onboarding:
             OnboardingView()


### PR DESCRIPTION
## ✨ What's this PR?
### 📌 관련 이슈 (Related Issue)
- Closes #30

---

### 🧶 주요 변경 내용 (Summary)

- 새로운 컴포넌트 `HomeEditView` 추가 (홈 화면 편집)
- 새로운 서브 컴포넌트 `BusStationEditView` 추가 (정류장 카드)
- `AppRoute`에 `homeedit([BusStationData])` 케이스 추가
- `HomeView`에서 편집 버튼 클릭 시 HomeEdit 화면으로 네비게이션 구현

---

### 📸 스크린샷 (Optional)

<!-- HomeEdit 화면 스크린샷 추가 -->

---

### 🧪 테스트 / 검증 내역

- [x] HomeView에서 편집 버튼 클릭 시 HomeEdit 화면 이동 확인
- [x] HomeEdit 화면에 정류장 목록 표시 확인
- [x] 네비게이션 바 정상 동작 확인 (뒤로가기 버튼, 타이틀)
- [x] BusStationEditView 카드 UI 정상 렌더링
- [ ] 드래그 앤 드롭 순서 변경 기능은 다음 커밋에서 구현 예정
- [ ] 삭제 버튼 동작은 다음 커밋에서 구현 예정

---

### 💬 기타 공유 사항

- `BusStationEditView`에 드래그 핸들(`line.3.horizontal`)과 삭제 버튼(`trash`) 아이콘은 추가되었지만, 실제 동작은 아직 구현되지 않았습니다
- 정류장 순서 변경 및 삭제 기능은 후속 커밋에서 구현할 예정입니다
- 현재는 더미 데이터(`busStationData`)를 사용하며, 실제 데이터 저장은 추후 이슈로 분리 예정

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)

- `HomeEditView.swift`의 네비게이션 바 구현 방식 (.toolbar 사용)
- `BusStationEditView.swift`의 카드 레이아웃 구조
- `AppRouter.swift`에서 데이터 전달 방식 ([BusStationData] 배열)