### PR TITLE
✨ Feature: 버스 정류장 화면 실 API 연동 #39

### DIFF
--- a/OffStageApp/Sources/Presentation/BusStation/BusStationViewModel.swift
+++ b/OffStageApp/Sources/Presentation/BusStation/BusStationViewModel.swift
@@ -1,0 +1,127 @@
+import BusAPI
+import Foundation
+
+@MainActor
+final class BusStationViewModel: ObservableObject {
+    enum ViewState {
+        case idle
+        case loading
+        case success([RouteDetail])
+        case error(Error)
+    }
+
+    struct RouteDetail: Identifiable, Hashable {
+        struct Arrival: Identifiable, Hashable {
+            let id = UUID()
+            let secondsUntilArrival: Int?
+            let remainingStops: Int?
+            let vehicleType: String?
+
+            var arrivalDescription: String {
+                guard let seconds = secondsUntilArrival else { return "정보 없음" }
+                return seconds < 60 ? "곧 도착" : "\(seconds / 60)분"
+            }
+
+            var remainingStopsDescription: String? {
+                guard let remainingStops else { return nil }
+                return "\(remainingStops)번째전"
+            }
+
+            var vehicleDescription: String? {
+                guard let vehicleType, !vehicleType.isEmpty else { return nil }
+                return vehicleType
+            }
+        }
+
+        let routeNumber: String
+        let routeType: String?
+        let arrivals: [Arrival]
+
+        var id: String { routeNumber }
+    }
+
+    let input: BusStationViewInput
+    @Published private(set) var viewState: ViewState = .idle
+
+    private let arrivalsFetcher: @Sendable (String, String) async throws -> [BusArrival]
+
+    init(input: BusStationViewInput, busRepository: BusRepository) {
+        self.input = input
+        arrivalsFetcher = { cityCode, nodeId in
+            try await busRepository.fetchStopArrivals(cityCode: cityCode, nodeId: nodeId)
+        }
+    }
+
+    init(
+        input: BusStationViewInput,
+        arrivalsFetcher: @escaping @Sendable (String, String) async throws -> [BusArrival]
+    ) {
+        self.input = input
+        self.arrivalsFetcher = arrivalsFetcher
+    }
+
+    func load() {
+        guard case .idle = viewState else { return }
+        viewState = .loading
+        Task { await fetchArrivals() }
+    }
+
+    func refresh() {
+        viewState = .loading
+        Task { await fetchArrivals() }
+    }
+
+    private func fetchArrivals() async {
+        do {
+            let arrivals = try await arrivalsFetcher(input.cityCode, input.nodeId)
+            print("BusStationViewModel - Fetched arrivals: \(arrivals)")
+
+            let grouped = Dictionary(grouping: arrivals, by: \.routeNumber)
+
+            let details = grouped.keys.sorted().map { routeNumber -> RouteDetail in
+                let arrivalsForRoute = (grouped[routeNumber] ?? [])
+                    .sorted {
+                        ($0.estimatedArrivalTime ?? Int.max) < ($1.estimatedArrivalTime ?? Int.max)
+                    }
+
+                let mappedArrivals = arrivalsForRoute.map { arrival in
+                    RouteDetail.Arrival(
+                        secondsUntilArrival: arrival.estimatedArrivalTime,
+                        remainingStops: arrival.remainingStopCount,
+                        vehicleType: arrival.vehicleType
+                    )
+                }
+
+                return RouteDetail(
+                    routeNumber: routeNumber,
+                    routeType: arrivalsForRoute.first?.routeType,
+                    arrivals: mappedArrivals
+                )
+            }
+            print("DETAIL \n\n\n\n\n\(details)\n\n\n\n\n\n")
+
+            viewState = .success(details)
+        } catch {
+            viewState = .error(error)
+        }
+    }
+}
+
+extension BusStationViewModel.RouteDetail {
+    static let sample: Self = .init(
+        routeNumber: "111",
+        routeType: "간선버스",
+        arrivals: [
+            .init(secondsUntilArrival: 480, remainingStops: 2, vehicleType: "저상"),
+            .init(secondsUntilArrival: 1320, remainingStops: 12, vehicleType: nil),
+        ]
+    )
+}
+
+#if DEBUG
+    extension BusStationViewModel {
+        func applyPreviewState(_ state: ViewState) {
+            viewState = state
+        }
+    }
+#endif

--- a/OffStageApp/Sources/Presentation/BusStation/SubView/BusStationListSubView.swift
+++ b/OffStageApp/Sources/Presentation/BusStation/SubView/BusStationListSubView.swift
@@ -7,24 +7,19 @@
 import SwiftUI
 
 struct BusStationListSubView: View {
-    let buses: [BusSampleData]
+    let routes: [BusStationViewModel.RouteDetail]
 
     var body: some View {
-        VStack {
-            ForEach(buses) { sampleItem in
-                BusStationRowSubView(sampleItem: sampleItem)
-                // 버스들 중간에 들어가는 분리 선, 표시되는 버스가 마지막 버스가 아니면 분리 선 표시!
-                if sampleItem.id != buses.last?.id {
+        VStack(spacing: 0) {
+            ForEach(routes) { route in
+                BusStationRowSubView(route: route)
+                if route.id != routes.last?.id {
                     Divider()
                 }
             }
-            .padding(5)
         }
         .padding()
-        .background(.gray.opacity(0.2))
+        .background(Color(.systemGray6))
+        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
     }
-}
-
-#Preview {
-    BusStationListSubView(buses: busSampleData)
 }

--- a/OffStageApp/Sources/Presentation/BusStation/SubView/BusStationRowSubView.swift
+++ b/OffStageApp/Sources/Presentation/BusStation/SubView/BusStationRowSubView.swift
@@ -7,46 +7,56 @@
 import SwiftUI
 
 struct BusStationRowSubView: View {
-    let sampleItem: BusSampleData
-    @State private var isSavedOn: Bool = false
+    let route: BusStationViewModel.RouteDetail
+    @State private var isSavedOn = false
 
     var body: some View {
-        HStack {
-            VStack {
+        HStack(alignment: .top) {
+            VStack(alignment: .leading, spacing: 8) {
                 HStack {
-                    // 버스 번호 표시
-                    Text("\(Image(systemName: "bus.fill")) \(sampleItem.routeNumber)")
+                    Label(route.routeNumber, systemImage: "bus.fill")
                         .font(.title3)
+                        .fontWeight(.semibold)
                     Spacer()
                 }
-                HStack {
-                    // 방면 표시(종점)
-                    Text("\(sampleItem.endnodenm)") // 방면 표시(종점)
-                        .foregroundColor(.gray)
-                    Spacer()
+                if let routeType = route.routeType, !routeType.isEmpty {
+                    Text(routeType)
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
                 }
-                HStack {
-                    // 1번째 도착버스 도착시간표시(초단위로 받을 시 분으로 표시)
-                    Text("\(sampleItem.arrivalMinutes1 / 60)분")
-                        .foregroundColor(.green)
-                    // 1번째 도착버스 몇정거장 전인지 표시
-                    Text("\(sampleItem.stopsAway1)번째전")
-                        .foregroundColor(.gray)
-                    // 2번째 도착버스 도착시간표시(초단위로 받을 시 분으로 표시)
-                    Text("\(sampleItem.arrivalMinutes2 / 60)분")
-                        .foregroundColor(.green)
-                    // 2번째 도착버스 몇정거장 전인지 표시
-                    Text("\(sampleItem.stopsAway2)번째전")
-                        .foregroundColor(.gray)
-                    Spacer()
+
+                if route.arrivals.isEmpty {
+                    Text("도착 예정 정보가 없습니다.")
+                        .foregroundColor(.secondary)
+                } else {
+                    HStack(spacing: 8) {
+                        ForEach(route.arrivals) { arrival in
+                            HStack(spacing: 8) {
+                                Text(arrival.arrivalDescription)
+                                    .fontWeight(.semibold)
+                                    .foregroundColor(.green)
+                                if let remaining = arrival.remainingStopsDescription {
+                                    Text(remaining)
+                                        .foregroundColor(.secondary)
+                                }
+                                /** voice over 라벨링으로 활용
+                                  if let vehicle = arrival.vehicleDescription {
+                                      Text(vehicle)
+                                          .foregroundColor(.secondary)
+                                  }
+                                 */
+                            }
+                            .font(.footnote)
+                        }
+                    }
                 }
             }
-            /// 즐겨찾기 버튼
+
             CircularToggleButton(isOn: $isSavedOn)
         }
     }
 }
 
 #Preview {
-    BusStationRowSubView(sampleItem: busSampleData[0])
+    BusStationRowSubView(route: .sample)
 }

--- a/OffStageApp/Sources/Presentation/Common/Models/BusStationViewInput.swift
+++ b/OffStageApp/Sources/Presentation/Common/Models/BusStationViewInput.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// Immutable data passed into `BusStationView`.
+struct BusStationViewInput: Hashable {
+    let cityCode: String
+    let nodeId: String
+    let nodeName: String
+    let nodeNumber: String?
+    let routes: [String]
+}

--- a/OffStageApp/Sources/Presentation/Home/HomeView.swift
+++ b/OffStageApp/Sources/Presentation/Home/HomeView.swift
@@ -45,6 +45,8 @@ class BusStopForHome {
     var nodenm: String
     /// 정류소 번호
     var nodeno: String
+    var nodeId: String
+    var cityCode: String
     /// 이 정류장을 지나는 버스들
     var routes: [BusSampleData]
 
@@ -52,11 +54,15 @@ class BusStopForHome {
         id: UUID = UUID(),
         stationName: String,
         stationNumber: String,
+        nodeId: String,
+        cityCode: String,
         busRoutes: [BusSampleData]
     ) {
         self.id = id
         nodenm = stationName
         nodeno = stationNumber
+        self.nodeId = nodeId
+        self.cityCode = cityCode
         routes = busRoutes
     }
 }
@@ -109,13 +115,17 @@ let busStationData: [BusStopForHome] = [
     BusStopForHome(
         id: UUID(),
         stationName: "포항공과대학교",
-        stationNumber: "12341234",
+        stationNumber: "37710",
+        nodeId: "PHB8000123",
+        cityCode: "37010",
         busRoutes: busSampleData.filter { $0.stationNumber == "12341234" }
     ),
     BusStopForHome(
         id: UUID(),
         stationName: "효자시장",
-        stationNumber: "12312312",
+        stationNumber: "37734",
+        nodeId: "PHB8000124",
+        cityCode: "37010",
         busRoutes: busSampleData.filter { $0.stationNumber == "12312312" }
     ),
 ]
@@ -141,94 +151,81 @@ struct HomeView: View {
 
     var body: some View {
         VStack {
-            Button {
-                // 검색 페이지로 이동
-                router.push(.search)
-            } label: {
-                HStack {
-                    Image(systemName: "magnifyingglass")
-                        .foregroundColor(.gray)
+            VStack {
+                Button {
+                    // 검색 페이지로 이동
+                    router.push(.search)
+                } label: {
+                    HStack {
+                        Image(systemName: "magnifyingglass")
+                            .foregroundColor(.gray)
 
-                    Text("버스 노선, 정류장 검색")
-                        .foregroundColor(.gray)
-                        .frame(maxWidth: .infinity, alignment: .leading)
+                        Text("버스 노선, 정류장 검색")
+                            .foregroundColor(.gray)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                    .padding()
+                    .background(Color(.systemGray6))
+                    .cornerRadius(10)
                 }
                 .padding()
-                .background(Color(.systemGray6))
-                .cornerRadius(10)
-            }
-            .padding()
-            .background(.gray.opacity(0.1))
+                .background(.gray.opacity(0.1))
 
-            ScrollView {
-                Text("홈")
-                    .font(.largeTitle)
-                    .frame(maxWidth: .infinity, alignment: .init(horizontal: .leading, vertical: .center))
-                    .padding(.horizontal)
-
-                if let busStationData {
-                    ForEach(busStationData) { station in
-                        // 정류소 번호를 전달(버스 필터링용)
-                        BusStationCardSubView(
-                            busStopData: station,
-                            isNotificationOn: activatedNodeID == station.id.uuidString,
-                            activateNotification: {
-                                if activatedNodeID == station.id.uuidString {
-                                    activatedNodeID = ""
-                                } else {
-                                    activatedNodeID = station.id.uuidString
-                                }
-                            }
-                        )
+                ScrollView {
+                    Text("홈")
+                        .font(.largeTitle)
+                        .frame(maxWidth: .infinity, alignment: .init(horizontal: .leading, vertical: .center))
                         .padding(.horizontal)
-                    }
-                    .padding(.vertical)
 
-                    Button("편집") {
-                        router.push(.homeedit)
-                    }
-                    .padding(.bottom)
+                    if let busStationData {
+                        ForEach(busStationData) { station in
+                            BusStationCardSubView(
+                                stationName: station.nodenm,
+                                stationNumber: station.nodeno,
+                                nodeId: station.nodeId,
+                                cityCode: station.cityCode
+                            )
+                            .padding(.horizontal)
+                        }
+                        .padding(.vertical)
 
-                } else {
-                    Text("저장된 내역이 없습니다.")
-                        .foregroundColor(.gray)
-                        .padding(.top, 50)
+                        Button("편집") {
+                            router.push(.homeedit)
+                        }
                         .padding(.bottom)
-                    Text("자주 이용하는 버스를 추가해 주세요.")
-                        .foregroundColor(.gray)
-                        .padding(.bottom, 30)
+                    } else {
+                        Text("저장된 내역이 없습니다.")
+                            .foregroundColor(.gray)
+                            .padding(.top, 50)
+                            .padding(.bottom)
+                        Text("자주 이용하는 버스를 추가해 주세요.")
+                            .foregroundColor(.gray)
+                            .padding(.bottom, 30)
 
-                    Button {
-                        router.push(.search)
-                    } label: {
-                        Text("나의 버스 추가하기")
-                            .foregroundColor(.white)
-                            .padding(.horizontal, 20)
-                            .padding(.vertical, 10)
-                            .background(Color.blue)
-                            .cornerRadius(20)
+                        Button {
+                            router.push(.search)
+                        } label: {
+                            Text("나의 버스 추가하기")
+                                .foregroundColor(.white)
+                                .padding(.horizontal, 20)
+                                .padding(.vertical, 10)
+                                .background(Color.blue)
+                                .cornerRadius(20)
+                        }
+
+                        Spacer()
                     }
 
-                    Spacer()
-                }
-                Button("버스 검색으로 이동") {
-                    router.push(.search)
-                }
-
-                Button("버스 정류장으로 이동 (데이터 전달)") {
-                    router.push(.busstation(busStopInfo: sampleBusStop))
-                }
-
-                Button("TestView로 이동 (데이터 전달)") {
-                    router.push(.test(busStopInfo: sampleBusStop))
-                }
-
-                Button("비전 버스 켜기") {
-                    router.push(.busvision(routeToDetect: ["1142"]))
+                    Divider()
+                    Button("TestView로 이동 (데이터 전달)") {
+                        router.push(.test(busStopInfo: sampleBusStop))
+                    }
+                    Button("비전 버스 켜기") {
+                        router.push(.busvision(routeToDetect: ["1142"]))
+                    }
                 }
             }
-        }
-        .onAppear {
+        }.onAppear {
             fetchData()
         }
     }
@@ -241,7 +238,9 @@ extension HomeView {
             BusStopForHome(
                 id: UUID(),
                 stationName: "포항공과대학교",
-                stationNumber: "12341234",
+                stationNumber: "37710",
+                nodeId: "PHB8000123",
+                cityCode: "37010",
                 busRoutes: busSampleData.filter {
                     $0.stationNumber == "12341234"
                 }
@@ -249,7 +248,9 @@ extension HomeView {
             BusStopForHome(
                 id: UUID(),
                 stationName: "효자시장",
-                stationNumber: "12312312",
+                stationNumber: "37734",
+                nodeId: "PHB8000124",
+                cityCode: "37010",
                 busRoutes: busSampleData.filter {
                     $0.stationNumber == "12312312"
                 }

--- a/OffStageApp/Sources/Presentation/Home/SubView/BusRouteListSubView.swift
+++ b/OffStageApp/Sources/Presentation/Home/SubView/BusRouteListSubView.swift
@@ -1,15 +1,23 @@
+import BusAPI // Import BusAPI for BusArrival
 import SwiftUI
 
 struct BusRouteListSubView: View {
-    let buses: [BusSampleData]
+    let busArrivals: [BusArrival]
+
     var body: some View {
         VStack {
-            // 배열에 있는 버스 정보들를 표시
-            ForEach(buses) { sampleItem in
-                BusRouteRowSubView(sampleItem: sampleItem)
-                // 버스들 중간에 들어가는 분리 선, 표시되는 버스가 마지막 버스가 아니면 분리 선 표시!
-                if sampleItem.id != buses.last?.id {
-                    Divider()
+            // Group arrivals by route number
+            ForEach(busArrivals.groupedByRouteNumber().keys.sorted(), id: \.self) {
+                routeNumber in
+                if let arrivalsForRoute = busArrivals.groupedByRouteNumber()[routeNumber] {
+                    BusRouteRowSubView(
+                        routeNumber: routeNumber,
+                        arrivals: arrivalsForRoute
+                    )
+                    // Add a Divider if it's not the last route
+                    if routeNumber != busArrivals.groupedByRouteNumber().keys.sorted().last {
+                        Divider()
+                    }
                 }
             }
             .padding(5)
@@ -20,6 +28,46 @@ struct BusRouteListSubView: View {
     }
 }
 
+// Helper extension to group BusArrivals by routeNumber
+extension [BusArrival] {
+    func groupedByRouteNumber() -> [String: [BusArrival]] {
+        Dictionary(grouping: self, by: \.routeNumber)
+    }
+}
+
 #Preview {
-    BusRouteListSubView(buses: busSampleData)
+    // Sample BusArrival data for preview
+    let sampleArrivals: [BusArrival] = [
+        BusArrival(
+            routeId: "GGB204000013",
+            routeNumber: "111",
+            routeType: "일반버스",
+            nodeId: "GGB204000163",
+            nodeName: "판교",
+            remainingStopCount: 2,
+            estimatedArrivalTime: 480,
+            vehicleType: "저상"
+        ),
+        BusArrival(
+            routeId: "GGB204000013",
+            routeNumber: "111",
+            routeType: "일반버스",
+            nodeId: "GGB204000163",
+            nodeName: "판교",
+            remainingStopCount: 13,
+            estimatedArrivalTime: 1320,
+            vehicleType: nil
+        ),
+        BusArrival(
+            routeId: "GGB204000065",
+            routeNumber: "9607",
+            routeType: "직행좌석버스",
+            nodeId: "GGB204000163",
+            nodeName: "판교",
+            remainingStopCount: 1,
+            estimatedArrivalTime: 300,
+            vehicleType: nil
+        ),
+    ]
+    return BusRouteListSubView(busArrivals: sampleArrivals)
 }

--- a/OffStageApp/Sources/Presentation/Home/SubView/BusRouteRowSubView.swift
+++ b/OffStageApp/Sources/Presentation/Home/SubView/BusRouteRowSubView.swift
@@ -2,35 +2,31 @@ import BusAPI
 import SwiftUI
 
 struct BusRouteRowSubView: View {
-    let sampleItem: BusSampleData
+    let routeNumber: String
+    let arrivals: [BusArrival]
 
     var body: some View {
         VStack {
             HStack {
                 // 버스 번호 표시
-                Text("\(Image(systemName: "bus.fill")) \(sampleItem.routeNumber)")
+                Text("\(Image(systemName: "bus.fill")) \(routeNumber)")
                     .font(.title3)
                 Spacer()
             }
             HStack {
-                // 방면 표시(종점)
-                Text("\(sampleItem.endnodenm)") // 방면 표시(종점)
-                    .foregroundColor(.gray)
-                Spacer()
-            }
-            HStack {
-                // 1번째 도착버스 도착시간표시(초단위로 받을 시 분으로 표시)
-                Text("\(sampleItem.arrivalMinutes1 / 60)분")
-                    .foregroundColor(.green)
-                // 1번째 도착버스 몇정거장 전인지 표시
-                Text("\(sampleItem.stopsAway1)번째전")
-                    .foregroundColor(.gray)
-                // 2번째 도착버스 도착시간표시(초단위로 받을 시 분으로 표시)
-                Text("\(sampleItem.arrivalMinutes2 / 60)분")
-                    .foregroundColor(.green)
-                // 2번째 도착버스 몇정거장 전인지 표시
-                Text("\(sampleItem.stopsAway2)번째전")
-                    .foregroundColor(.gray)
+                // Display up to two arrivals
+                ForEach(arrivals.prefix(2).indices, id: \.self) {
+                    index in
+                    let arrival = arrivals[index]
+                    if let estimatedArrivalTime = arrival.estimatedArrivalTime {
+                        Text("\(estimatedArrivalTime / 60)분")
+                            .foregroundColor(.green)
+                    }
+                    if let remainingStopCount = arrival.remainingStopCount {
+                        Text("\(remainingStopCount)번째전")
+                            .foregroundColor(.gray)
+                    }
+                }
                 Spacer()
             }
         }
@@ -38,5 +34,28 @@ struct BusRouteRowSubView: View {
 }
 
 #Preview {
-    BusRouteRowSubView(sampleItem: busSampleData[0])
+    // Sample BusArrival data for preview
+    let sampleArrivals: [BusArrival] = [
+        BusArrival(
+            routeId: "GGB204000013",
+            routeNumber: "111",
+            routeType: "일반버스",
+            nodeId: "GGB204000163",
+            nodeName: "판교",
+            remainingStopCount: 2,
+            estimatedArrivalTime: 480,
+            vehicleType: "저상"
+        ),
+        BusArrival(
+            routeId: "GGB204000013",
+            routeNumber: "111",
+            routeType: "일반버스",
+            nodeId: "GGB204000163",
+            nodeName: "판교",
+            remainingStopCount: 13,
+            estimatedArrivalTime: 1320,
+            vehicleType: nil
+        ),
+    ]
+    return BusRouteRowSubView(routeNumber: "111", arrivals: sampleArrivals)
 }

--- a/OffStageApp/Sources/Presentation/Home/SubView/BusStationCardSubView.swift
+++ b/OffStageApp/Sources/Presentation/Home/SubView/BusStationCardSubView.swift
@@ -1,20 +1,34 @@
+import BusAPI
 import SwiftUI
 
 struct BusStationCardSubView: View {
     @EnvironmentObject var router: Router<AppRoute>
+    @StateObject private var viewModel: BusStationCardViewModel
 
-    let busStopData: BusStopForHome
-    let isNotificationOn: Bool
-    let activateNotification: () -> Void
+    let stationName: String
+    let stationNumber: String
+    let nodeId: String
+    let cityCode: String
+
+    // 더미파일(실제 데이터 넣을 때는 삭제)
+    @State private var isNotificationOn = false
 
     init(
-        busStopData: BusStopForHome,
-        isNotificationOn: Bool,
-        activateNotification: @escaping () -> Void
+        stationName: String,
+        stationNumber: String,
+        nodeId: String,
+        cityCode: String,
+        busRepository: BusRepository = DefaultBusRepository()
     ) {
-        self.busStopData = busStopData
-        self.isNotificationOn = isNotificationOn
-        self.activateNotification = activateNotification
+        self.stationName = stationName
+        self.stationNumber = stationNumber
+        self.nodeId = nodeId
+        self.cityCode = cityCode
+        _viewModel = StateObject(wrappedValue: BusStationCardViewModel(
+            busRepository: busRepository,
+            nodeId: nodeId,
+            cityCode: cityCode
+        ))
     }
 
     var body: some View {
@@ -22,31 +36,31 @@ struct BusStationCardSubView: View {
             HStack {
                 VStack(alignment: .leading) {
                     // 정류소 이름 표시
-                    Text("\(busStopData.nodenm)")
+                    Text("\(stationName)")
                         .font(.title2)
                     // 정류소 번호 표시
-                    Text("\(busStopData.nodeno)")
+                    Text("\(stationNumber)")
                         .foregroundColor(.gray)
                 }
                 Spacer()
                 // 알림 버튼
-                Button(action: activateNotification) {
-                    Image(systemName: isNotificationOn ? "bell.fill" : "bell")
-                        .font(.title2)
-                        .foregroundColor(isNotificationOn ? .white : .gray)
-                        .padding(8)
-                        .background {
-                            Circle()
-                                .stroke(lineWidth: 2)
-                                .foregroundStyle(isNotificationOn ? .blue : .gray)
-                        }
-                }
+                //                Button(action: activateNotification) {
+                //                    Image(systemName: isNotificationOn ? "bell.fill" : "bell")
+                //                        .font(.title2)
+                //                        .foregroundColor(isNotificationOn ? .white : .gray)
+                //                        .padding(8)
+                //                        .background {
+                //                            Circle()
+                //                                .stroke(lineWidth: 2)
+                //                                .foregroundStyle(isNotificationOn ? .blue : .gray)
+                //                        }
+                //                }
             }
             .padding([.top, .leading, .trailing])
 
             if isNotificationOn == true {
                 Button {
-                    router.push(.busvision(routeToDetect: routes))
+                    router.push(.busvision(routeToDetect: [""]))
                 } label: {
                     Text("\(Image(systemName: "camera")) 버스 인식하기")
                         .foregroundColor(.white)
@@ -58,31 +72,17 @@ struct BusStationCardSubView: View {
                 .padding()
             }
 
-            BusRouteListSubView(buses: busStopData.routes)
+            BusRouteListSubView(busArrivals: viewModel.busArrivals)
         }
         .background(.gray.opacity(0.1))
         .cornerRadius(15)
-        .overlay {
-            RoundedRectangle(cornerRadius: 15)
-                .stroke(
-                    isNotificationOn ? .blue : .clear,
-                    lineWidth: 2
-                )
+        .task {
+            await viewModel.fetchArrivals()
         }
-    }
-}
-
-extension BusStationCardSubView {
-    /// busvision에 전달하기 위한 계산 프로퍼티
-    var routes: [String] {
-        busStopData.routes.compactMap(\.routeNumber)
     }
 }
 
 #Preview {
-    BusStationCardSubView(
-        busStopData: busStationData[0],
-        isNotificationOn: true,
-        activateNotification: {}
-    )
+    BusStationCardSubView(stationName: "포항공과대학교", stationNumber: "12341234", nodeId: "GGB204000163", cityCode: "31020")
+        .environmentObject(Router<AppRoute>(root: .home))
 }

--- a/OffStageApp/Sources/Presentation/Home/SubView/BusStationCardViewModel.swift
+++ b/OffStageApp/Sources/Presentation/Home/SubView/BusStationCardViewModel.swift
@@ -1,0 +1,27 @@
+import BusAPI
+import Foundation
+
+@MainActor
+final class BusStationCardViewModel: ObservableObject {
+    @Published private(set) var busArrivals: [BusArrival] = []
+    private let busRepository: BusRepository
+    private let nodeId: String
+    private let cityCode: String
+
+    init(busRepository: BusRepository, nodeId: String, cityCode: String) {
+        self.busRepository = busRepository
+        self.nodeId = nodeId
+        self.cityCode = cityCode
+    }
+
+    func fetchArrivals() async {
+        do {
+            let arrivals = try await busRepository.fetchStopArrivals(cityCode: cityCode, nodeId: nodeId)
+            print("BusStationCardViewModel - Fetched arrivals: \(arrivals)")
+            busArrivals = arrivals
+        } catch {
+            print("Error fetching arrivals: \(error)")
+            // Handle error appropriately, e.g., set an error state
+        }
+    }
+}

--- a/OffStageApp/Sources/Presentation/Routing/AppRouter.swift
+++ b/OffStageApp/Sources/Presentation/Routing/AppRouter.swift
@@ -4,8 +4,8 @@ import SwiftUI
 enum AppRoute: Routable {
     case home
     case search
-    case busstation(busStopInfo: BusStopInfo)
     case busvision(routeToDetect: [String])
+    case busstation(input: BusStationViewInput)
     case homeedit
     case onboarding
     case test(busStopInfo: BusStopInfo)
@@ -21,8 +21,8 @@ enum AppRoute: Routable {
             let viewModel = SearchViewModel(busRepository: DefaultBusRepository(), locationManager: LocationManager())
             SearchView(viewModel: viewModel)
 
-        case .busstation:
-            BusStationView()
+        case let .busstation(input):
+            BusStationView(input: input)
 
         case let .busvision(routeToDetect):
             BusVisionView(routeNumbers: routeToDetect)

--- a/OffStageApp/Sources/Presentation/Search/SearchView.swift
+++ b/OffStageApp/Sources/Presentation/Search/SearchView.swift
@@ -40,13 +40,6 @@ struct SearchView: View {
                     }
                 }
                 .padding(.horizontal, 16)
-                .navigationBarItems(leading:
-                    Button(action: {
-                        router.popToRoot()
-                    }, label: {
-                        Image(systemName: "chevron.left")
-                    })
-                )
                 .toolbar {
                     ToolbarItem(placement: .principal) { // 툴바 항목 배치
                         TextField("검색...", text: $viewModel.searchTerm)
@@ -68,13 +61,10 @@ private extension SearchView {
     func stopList(_ stops: [BusStopForSearch]) -> some View {
         VStack(spacing: 0) {
             ForEach(stops) { busStop in
-                Button(action: {
-                    // TODO: Fix navigation
-                    // router.push(.busstation(busStopInfo: busStopInfo))
-                }) {
-                    SearchResultsView(busStop: busStop)
+                SearchResultsView(busStop: busStop) {
+                    guard let input = viewModel.destinationInput(for: busStop) else { return }
+                    router.push(.busstation(input: input))
                 }
-                .buttonStyle(PlainButtonStyle())
             }
             Divider()
                 .overlay(Color.gray.opacity(0.2))

--- a/OffStageApp/Sources/Presentation/Search/SubView/BusStopForSearch.swift
+++ b/OffStageApp/Sources/Presentation/Search/SubView/BusStopForSearch.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 struct BusStopForSearch: Identifiable {
-    let id = UUID()
+    let id: UUID
     /// 정류소이름
     let nodenm: String
     /// 정류소 번호
@@ -11,6 +11,20 @@ struct BusStopForSearch: Identifiable {
     let routes: [String]
     /// 거리(검색결과일 땐 안보이는)
     let distance: String?
+
+    init(
+        id: UUID = UUID(),
+        nodenm: String,
+        nodeno: String?,
+        routes: [String],
+        distance: String?
+    ) {
+        self.id = id
+        self.nodenm = nodenm
+        self.nodeno = nodeno
+        self.routes = routes
+        self.distance = distance
+    }
 }
 
 extension BusStopForSearch {

--- a/OffStageApp/Sources/Presentation/Search/SubView/SearchResultsView.swift
+++ b/OffStageApp/Sources/Presentation/Search/SubView/SearchResultsView.swift
@@ -8,49 +8,53 @@ import SwiftUI
 
 struct SearchResultsView: View {
     let busStop: BusStopForSearch
+    let onSelect: () -> Void
 
     var body: some View {
-        VStack {
-            Divider()
-                .overlay(Color.gray.opacity(0.2))
-            VStack(alignment: .leading, spacing: 8) {
-                Text(busStop.nodenm)
-                    .font(.title2)
-                    .fontWeight(.bold)
-                if let nodeno = busStop.nodeno, !nodeno.isEmpty {
-                    Text("ID: \(nodeno)")
-                        .foregroundColor(.gray)
-                }
-                if let distance = busStop.distance {
-                    Text(distance)
+        Button(action: onSelect) {
+            VStack {
+                Divider()
+                    .overlay(Color.gray.opacity(0.2))
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(busStop.nodenm)
+                        .font(.title2)
                         .fontWeight(.bold)
-                        .foregroundStyle(.green)
-                }
-                HStack(alignment: .top, spacing: 8) {
-                    Image(systemName: "bus.fill")
-                        .foregroundStyle(.blue)
-                    if busStop.routes.isEmpty {
-                        Text("노선 정보를 불러올 수 없습니다.")
-                            .foregroundColor(.secondary)
-                    } else {
-                        Text(busStop.routes.joined(separator: ", "))
-                            .font(.callout)
-                            .foregroundColor(.primary)
+                    if let nodeno = busStop.nodeno, !nodeno.isEmpty {
+                        Text("ID: \(nodeno)")
+                            .foregroundColor(.gray)
                     }
-                    Spacer()
+                    if let distance = busStop.distance {
+                        Text(distance)
+                            .fontWeight(.bold)
+                            .foregroundStyle(.green)
+                    }
+                    HStack(alignment: .top, spacing: 8) {
+                        Image(systemName: "bus.fill")
+                            .foregroundStyle(.blue)
+                        if busStop.routes.isEmpty {
+                            Text("노선 정보를 불러올 수 없습니다.")
+                                .foregroundColor(.secondary)
+                        } else {
+                            Text(busStop.routes.joined(separator: ", "))
+                                .font(.callout)
+                                .foregroundColor(.primary)
+                        }
+                        Spacer()
+                    }
                 }
+                .padding(.vertical, 14)
+                .padding(.horizontal, 16)
             }
-            .padding(.vertical, 14)
-            .padding(.horizontal, 16)
+            .frame(maxWidth: .infinity)
+            .background(Color.gray.opacity(0.2))
         }
-        .frame(maxWidth: .infinity)
-        .background(Color.gray.opacity(0.2))
+        .buttonStyle(PlainButtonStyle())
     }
 }
 
 struct SearchResultsView_Previews: PreviewProvider {
     static var previews: some View {
         // Preview에서는 샘플 데이터를 사용
-        SearchResultsView(busStop: BusStopForSearch.sampleBusStop[0])
+        SearchResultsView(busStop: BusStopForSearch.sampleBusStop[0]) {}
     }
 }


### PR DESCRIPTION
## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
- Closes #39 

---

### 🧶 주요 변경 내용 (Summary)
- `BusStationViewModel`과 `BusStationViewInput`을 도입해 정류장 상세 화면이 Repository 기반 실시간 데이터를 구독하도록 구성했습니다.
- `BusStationView`가 로딩/성공/에러 상태를 처리하며, 노선이나 도착 정보가 비어 있을 때 안내 문구를 출력합니다.
- 홈 카드, 버스 정류장 리스트, 검색 결과 셀 등이 정류장 입력 모델을 생성해 상세 화면으로 이동하도록 라우팅을 통합했습니다.
- `BusStationListSubView`와 `BusStationRowSubView`에 실제 노선·도착 정보를 바인딩하고 UI를 다듬었습니다.
- 임시 테스트용 라우팅 버튼을 삭제하고 정류장 화면 진입 흐름을 일관되게 정리했습니다.

---

### 📸 스크린샷 (Optional)

https://github.com/user-attachments/assets/4a94f8db-af30-401e-b2e3-e8d49573f3c5



---

### 🧪 테스트 / 검증 내역
- [x] `tuist test --scheme BusAPITests --destination 'platform=iOS Simulator,name=iPhone 15'`
- [x] 시뮬레이터에서 정류장 상세 화면 진입 및 노선/도착 정보 로딩 확인
- [ ] 실기기 위치 기반 시나리오는 추후 점검 예정

---

### 💬 기타 공유 사항
- 공공데이터 API가 실제 경유하지 않는 노선을 반환하는 사례가 있어 브라우저 호출 시 자동 추가되는 파라미터를 조사 중입니다. 향후 조건을 파악해 요청에 반영해야 합니다.
- 도착 정보가 비어 있을 때 노출하는 메시지는 임시 문구이며, UI 가이드에 맞춰 후속 수정이 필요할 수 있습니다.

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
- 개발하다보니 MockData와 함께 바로 이동하는 버튼, Preview등을 많이.. 삭제했습니다..^^ 안정화 시키고 추가할게요오
- 남은시간의 경우 따로 뷰로직 내에서 갱신하는 코드를 담진 않았습니다! 몇 초 단위로 갱신할 지 이야기를 해봐야할 것 같다는 생각이 들어 TODO주석 남겼어요!
