### PR TITLE
✨ Feature: #43 즐겨찾기 기능 구현

### DIFF
--- a/OffStageApp/Sources/Domain/Favorite.swift
+++ b/OffStageApp/Sources/Domain/Favorite.swift
@@ -1,0 +1,41 @@
+import Foundation
+import SwiftData
+
+@Model
+final class Favorite {
+    /// cityCode, nodeId, routeId 를 조합한 즐겨찾기 고유 ID
+    @Attribute(.unique) var id: String
+    /// 도시코드
+    let cityCode: String
+    /// 정류소 ID
+    let nodeId: String
+    /// 정류소 번호
+    let nodeNo: String?
+    /// 노선 ID
+    let routeId: String
+    /// 정류소 이름
+    let nodeName: String
+    /// 노선 번호
+    let routeNo: String
+    /// 노선 방향
+    let direction: String
+
+    init(
+        cityCode: String,
+        nodeId: String,
+        nodeNo: String?,
+        routeId: String,
+        nodeName: String,
+        routeNo: String,
+        direction: String
+    ) {
+        id = "\(cityCode)-\(nodeId)-\(routeId)"
+        self.cityCode = cityCode
+        self.nodeId = nodeId
+        self.nodeNo = nodeNo
+        self.routeId = routeId
+        self.nodeName = nodeName
+        self.routeNo = routeNo
+        self.direction = direction
+    }
+}

--- a/OffStageApp/Sources/OffStageApp.swift
+++ b/OffStageApp/Sources/OffStageApp.swift
@@ -1,3 +1,4 @@
+import SwiftData
 import SwiftUI
 
 @main
@@ -8,5 +9,6 @@ struct OffStageApp: App {
         WindowGroup {
             RouterView(router: router)
         }
+        .modelContainer(for: Favorite.self)
     }
 }

--- a/OffStageApp/Sources/Presentation/BusStation/BusStationView.swift
+++ b/OffStageApp/Sources/Presentation/BusStation/BusStationView.swift
@@ -78,7 +78,7 @@ struct BusStationView: View {
                 .foregroundColor(.secondary)
                 .padding(.vertical, 40)
             } else {
-                BusStationListSubView(routes: routes)
+                BusStationListSubView(routes: routes, viewInput: viewModel.input)
                     .padding(.horizontal, 16)
             }
 

--- a/OffStageApp/Sources/Presentation/BusStation/SubView/BusStationListSubView.swift
+++ b/OffStageApp/Sources/Presentation/BusStation/SubView/BusStationListSubView.swift
@@ -1,18 +1,19 @@
-//
-//  BusStationListSubView.swift
-//  OffStage
-//
-//  Created by Murphy on 10/21/25.
-//
 import SwiftUI
 
 struct BusStationListSubView: View {
     let routes: [BusStationViewModel.RouteDetail]
+    let viewInput: BusStationViewInput
 
     var body: some View {
         VStack(spacing: 0) {
             ForEach(routes) { route in
-                BusStationRowSubView(route: route)
+                BusStationRowSubView(
+                    route: route,
+                    cityCode: viewInput.cityCode,
+                    nodeId: viewInput.nodeId,
+                    nodeNo: viewInput.nodeNumber,
+                    nodeName: viewInput.nodeName
+                )
                 if route.id != routes.last?.id {
                     Divider()
                 }

--- a/OffStageApp/Sources/Presentation/BusStation/SubView/CircularToggleButton.swift
+++ b/OffStageApp/Sources/Presentation/BusStation/SubView/CircularToggleButton.swift
@@ -7,14 +7,11 @@
 import SwiftUI
 
 struct CircularToggleButton: View {
-    @Binding var isOn: Bool
+    let isOn: Bool
+    let action: () -> Void
 
     var body: some View {
-        Button(action: {
-            withAnimation(.spring(response: 0.1)) {
-                isOn.toggle()
-            }
-        }) {
+        Button(action: action) {
             ZStack {
                 Circle()
                     .fill(isOn ? Color.blue : Color.clear)

--- a/OffStageApp/Sources/Presentation/Home/HomeView.swift
+++ b/OffStageApp/Sources/Presentation/Home/HomeView.swift
@@ -2,136 +2,11 @@ import BusAPI
 import SwiftData
 import SwiftUI
 
-// 더미 모델
-// 버스 데이터
-@Model
-class BusSampleData {
-    var id: UUID = UUID()
-    var routeNumber: String
-    var endnodenm: String
-    var arrivalMinutes1: Int
-    var arrivalMinutes2: Int
-    var stopsAway1: Int
-    var stopsAway2: Int
-    var stationNumber: String
-
-    init(
-        id: UUID = UUID(),
-        routeNumber: String,
-        endnodenm: String,
-        arrivalMinutes1: Int,
-        arrivalMinutes2: Int,
-        stopsAway1: Int,
-        stopsAway2: Int,
-        stationNumber: String
-    ) {
-        self.id = id
-        self.routeNumber = routeNumber
-        self.endnodenm = endnodenm
-        self.arrivalMinutes1 = arrivalMinutes1
-        self.arrivalMinutes2 = arrivalMinutes2
-        self.stopsAway1 = stopsAway1
-        self.stopsAway2 = stopsAway2
-        self.stationNumber = stationNumber
-    }
-}
-
-// 더미 모델
-// 정류소 데이터
-@Model
-class BusStopForHome {
-    var id: UUID
-    /// 정류소 이름
-    var nodenm: String
-    /// 정류소 번호
-    var nodeno: String
-    var nodeId: String
-    var cityCode: String
-    /// 이 정류장을 지나는 버스들
-    var routes: [BusSampleData]
-
-    init(
-        id: UUID = UUID(),
-        stationName: String,
-        stationNumber: String,
-        nodeId: String,
-        cityCode: String,
-        busRoutes: [BusSampleData]
-    ) {
-        self.id = id
-        nodenm = stationName
-        nodeno = stationNumber
-        self.nodeId = nodeId
-        self.cityCode = cityCode
-        routes = busRoutes
-    }
-}
-
-// 더미 데이터
-let busSampleData: [BusSampleData] = [
-    BusSampleData(
-        id: UUID(),
-        routeNumber: "111",
-        endnodenm: "시청방면",
-        arrivalMinutes1: 480,
-        arrivalMinutes2: 1320,
-        stopsAway1: 2,
-        stopsAway2: 13,
-        stationNumber: "12341234"
-    ),
-    BusSampleData(
-        id: UUID(),
-        routeNumber: "112",
-        endnodenm: "시청방면",
-        arrivalMinutes1: 470,
-        arrivalMinutes2: 1310,
-        stopsAway1: 1,
-        stopsAway2: 12,
-        stationNumber: "12341234"
-    ),
-    BusSampleData(
-        id: UUID(),
-        routeNumber: "212",
-        endnodenm: "효자시장방면",
-        arrivalMinutes1: 470,
-        arrivalMinutes2: 1310,
-        stopsAway1: 1,
-        stopsAway2: 12,
-        stationNumber: "12312312"
-    ),
-    BusSampleData(
-        id: UUID(),
-        routeNumber: "212",
-        endnodenm: "효자시장방면",
-        arrivalMinutes1: 470,
-        arrivalMinutes2: 1310,
-        stopsAway1: 1,
-        stopsAway2: 12,
-        stationNumber: "12312312"
-    ),
-]
-// 더미 데이터
-let busStationData: [BusStopForHome] = [
-    BusStopForHome(
-        id: UUID(),
-        stationName: "포항공과대학교",
-        stationNumber: "37710",
-        nodeId: "PHB8000123",
-        cityCode: "37010",
-        busRoutes: busSampleData.filter { $0.stationNumber == "12341234" }
-    ),
-    BusStopForHome(
-        id: UUID(),
-        stationName: "효자시장",
-        stationNumber: "37734",
-        nodeId: "PHB8000124",
-        cityCode: "37010",
-        busRoutes: busSampleData.filter { $0.stationNumber == "12312312" }
-    ),
-]
-
 struct HomeView: View {
     @EnvironmentObject var router: Router<AppRoute>
+    @Environment(\.modelContext) private var modelContext
+    @State private var locationProvider: LocationProviding = LocationManager()
+    @State private var notificationOnStationId: String?
 
     /// 숏컷 진입을 위한 더미 데이터. 추후 숏컷 삭제 시 함께 삭제
     private let sampleBusStop = BusStopInfo(
@@ -145,9 +20,23 @@ struct HomeView: View {
     )
 
     @State private var searchText = ""
-    @State private var activatedNodeID: String = ""
-    /// 홈화면에 필요한 데이터
-    @State private var busStationData: [BusStopForHome]?
+    @Query(sort: [
+        SortDescriptor<Favorite>(\Favorite.nodeName),
+        SortDescriptor<Favorite>(\Favorite.routeNo),
+    ]) private var favorites: [Favorite]
+
+    private var favoritedStops: [FavoritedStop] {
+        let grouped = Dictionary(grouping: favorites, by: { $0.nodeId })
+        return grouped.map { _, favorites in
+            FavoritedStop(favorites: favorites)
+        }.sorted {
+            if $0.nodeName != $1.nodeName {
+                $0.nodeName < $1.nodeName
+            } else {
+                $0.nodeId < $1.nodeId
+            }
+        }
+    }
 
     var body: some View {
         VStack {
@@ -177,17 +66,25 @@ struct HomeView: View {
                         .frame(maxWidth: .infinity, alignment: .init(horizontal: .leading, vertical: .center))
                         .padding(.horizontal)
 
-                    if let busStationData {
-                        ForEach(busStationData) { station in
+                    if !favoritedStops.isEmpty {
+                        ForEach(favoritedStops) { station in
                             BusStationCardSubView(
-                                stationName: station.nodenm,
-                                stationNumber: station.nodeno,
+                                stationName: station.nodeName,
+                                stationNumber: station.nodeNo ?? "",
                                 nodeId: station.nodeId,
-                                cityCode: station.cityCode
+                                cityCode: station.cityCode,
+                                favorites: station.favorites,
+                                isNotificationOn: station.id == notificationOnStationId,
+                                onNotificationTap: {
+                                    if notificationOnStationId == station.id {
+                                        notificationOnStationId = nil
+                                    } else {
+                                        notificationOnStationId = station.id
+                                    }
+                                }
                             )
                             .padding(.horizontal)
                         }
-                        .padding(.vertical)
 
                         Button("편집") {
                             router.push(.homeedit)
@@ -215,47 +112,23 @@ struct HomeView: View {
 
                         Spacer()
                     }
-
-                    Divider()
-                    Button("TestView로 이동 (데이터 전달)") {
-                        router.push(.test(busStopInfo: sampleBusStop))
-                    }
-                    Button("비전 버스 켜기") {
-                        router.push(.busvision(routeToDetect: ["1142"]))
-                    }
                 }
             }
-        }.onAppear {
-            fetchData()
+        }
+        .onAppear {
+            locationProvider.requestLocationPermission()
         }
     }
 }
 
 extension HomeView {
-    // TODO: 추후 VM에서 API 호출로 데이터 채우기
-    private func fetchData() {
-        busStationData = [
-            BusStopForHome(
-                id: UUID(),
-                stationName: "포항공과대학교",
-                stationNumber: "37710",
-                nodeId: "PHB8000123",
-                cityCode: "37010",
-                busRoutes: busSampleData.filter {
-                    $0.stationNumber == "12341234"
-                }
-            ),
-            BusStopForHome(
-                id: UUID(),
-                stationName: "효자시장",
-                stationNumber: "37734",
-                nodeId: "PHB8000124",
-                cityCode: "37010",
-                busRoutes: busSampleData.filter {
-                    $0.stationNumber == "12312312"
-                }
-            ),
-        ]
+    struct FavoritedStop: Identifiable {
+        let favorites: [Favorite]
+        var id: String { (favorites.first?.nodeId ?? "") + favorites.map(\.id).joined() }
+        var nodeId: String { favorites.first?.nodeId ?? "" }
+        var nodeName: String { favorites.first?.nodeName ?? "" }
+        var nodeNo: String? { favorites.first?.nodeNo }
+        var cityCode: String { favorites.first?.cityCode ?? "" }
     }
 }
 


### PR DESCRIPTION
## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #43

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- SwiftData를 이용한 즐겨찾기 데이터 모델(`Favorite`)을 추가했습니다.
- 홈 화면(`HomeView`)에서 사용자가 추가한 즐겨찾기 목록을 정류장별로 그룹화하여 보여주도록 리팩토링했습니다.
- 정류장 상세 화면(`BusStationRowSubView`)에 즐겨찾기 추가/삭제 기능을 구현하고, UI 상태가 즉시 반영되도록 수정했습니다.
- 홈 화면의 즐겨찾기 카드(`BusStationCardSubView`)가 개별적으로 실시간 도착 정보를 API로 호출하도록 로직을 변경했습니다.
- 홈 화면에서 단 하나의 즐겨찾기 카드만 알림(버스 비전 기능 활성화)을 켤 수 있도록 상태 관리 로직을 구현했습니다.
- 앱의 핵심 기능에 필요한 위치 정보 권한을 홈 화면 진입 시 요청하도록 구현했습니다.

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->
https://github.com/user-attachments/assets/d0c76dda-d2c3-4228-a49e-69b8e140271f

https://github.com/user-attachments/assets/4e5284ec-4e99-45d8-96b9-b663f76b2f5d




---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] 정류장 상세에서 즐겨찾기 추가/삭제 시 홈 화면에 정상적으로 반영되는지 확인
- [x] 홈 화면의 즐겨찾기 카드에 실시간 도착 정보가 표시되는지 확인
- [x] 알림 버튼이 정상적으로 동작하며, 하나의 카드에서만 활성화되는지 확인
- [x] 앱 최초 실행 시 위치 정보 권한 요청 팝업이 노출되는지 확인

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- 즐겨찾기 UI가 갱신되지 않는 문제를 해결하기 위해 `HomeView`의 `FavoritedStop` 모델의 `id`를 `favorites` 배열의 내용과 연동하여 변경되도록 수정했습니다. 이를 통해 SwiftUI가 `ForEach` 뷰를 올바르게 다시 렌더링하도록 유도했습니다.
- 각 즐겨찾기 카드가 개별적으로 API를 호출하는 현재 구조는 즐겨찾기 개수가 많아질 경우 성능 저하를 유발할 수 있습니다. 추후 `HomeViewModel`을 다시 도입하여 API 호출을 중앙에서 관리하는 방식으로 리팩토링을 고려해볼 수 있습니다.
