### PR TITLE
📝 Design: #45 홈 편집 뷰 임시 UI 구현

### DIFF
--- a/OffStageApp/Sources/Presentation/HomeEdit/HomeEditView.swift
+++ b/OffStageApp/Sources/Presentation/HomeEdit/HomeEditView.swift
@@ -4,20 +4,39 @@ struct HomeEditView: View {
     @EnvironmentObject var router: Router<AppRoute>
 
     var body: some View {
-        VStack(spacing: 16) {
-            Text("홈 편집 화면")
-                .font(.largeTitle)
-
-            Button("이전 화면으로 돌아가기 (pop)") {
-                router.pop()
+        VStack {
+            Rectangle()
+                .foregroundColor(.black)
+                .frame(height: 100)
+            
+            Text("추후 개발 예정입니다.")
+                .font(.title3)
+                .foregroundColor(.gray)
+            
+            Spacer()
+        }
+        .navigationBarBackButtonHidden(true)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button {
+                    router.pop()
+                } label: {
+                    Image(systemName: "chevron.left")
+                        .foregroundColor(.gray)
+                }
             }
 
-            Button("홈으로 돌아가기 (popToRoot)") {
-                router.popToRoot()
+            ToolbarItem(placement: .principal) {
+                VStack {
+                    Text("홈 화면 편집")
+                        .font(.title2)
+                        .foregroundColor(.gray)
+                }
+                .frame(height: 400)
             }
         }
-        .padding()
-        .navigationTitle("Home Edit")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarBackground(.visible, for: .navigationBar)
     }
 }
 


### PR DESCRIPTION
## ✨ What's this PR?
### 📌 관련 이슈 (Related Issue)
- Closes #45

---

### 🧶 주요 변경 내용 (Summary)

- HomeEditView에 "추후 개발 예정입니다." 안내 문구 추가
- 네비게이션 바 커스터마이징 (타이틀 "홈 화면 편집", 커스텀 뒤로가기 버튼)
- 테스트용 UI 요소 제거 (pop, popToRoot 버튼)
- 상단 배경 영역 확장

---

### 📸 스크린샷 (Optional)

<img width="260" height="510" alt="image" src="https://github.com/user-attachments/assets/0205a862-4e0b-4ebb-94a2-4f0d62acc2e8" />

---

### 🧪 테스트 / 검증 내역

- [x] 홈 화면에서 편집 화면 진입 시 안내 문구 정상 표시
- [x] 뒤로가기 버튼 동작 확인
- [x] 네비게이션 바 UI 정상 표시

---

### 💬 기타 공유 사항

- 실제 버스정류장 순서 배치 및 삭제 기능은 추후 별도 이슈로 개발 예정입니다
- 현재는 사용자에게 개발 예정임을 안내하는 임시 UI만 구현되었습니다

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)

- 전체적인 UI 레이아웃 및 안내 문구 확인
- 네비게이션 바 디자인 확인