### PR TITLE
✨ Feature: #42 실시간 탐지된 노선 번호를 BusVisionView에 표시

### DIFF
--- a/OffStageApp/Sources/Presentation/BusVision/BusDetectionView.swift
+++ b/OffStageApp/Sources/Presentation/BusVision/BusDetectionView.swift
@@ -8,11 +8,15 @@ import SwiftUI
 
 /// BusDetectionViewController를 SwiftUI에서 쓸 수 있도록 처리
 struct BusDetectionView: UIViewControllerRepresentable {
-    let routeNumbers: [String]
+    let routeNumbersToDetect: [String]
+    @Binding var detectedRouteNumbers: [String]
 
     func makeUIViewController(context _: Context) -> BusDetectionViewController {
         let vc = BusDetectionViewController()
-        vc.routeNumbersToDetect = routeNumbers
+        vc.routeNumbersToDetect = routeNumbersToDetect
+        vc.onDetectedRouteNumbersChanged = { detected in
+            detectedRouteNumbers = detected
+        }
         return vc
     }
 

--- a/OffStageApp/Sources/Presentation/BusVision/BusDetectionViewController.swift
+++ b/OffStageApp/Sources/Presentation/BusVision/BusDetectionViewController.swift
@@ -6,6 +6,8 @@ import Vision
 final class BusDetectionViewController: UIViewController {
     /// 인식할 노선번호
     var routeNumbersToDetect: [String] = []
+    /// 감지된 노선번호 배열이 변경될 때 SwiftUI에서 처리하기 위한 클로저
+    var onDetectedRouteNumbersChanged: (([String]) -> Void)?
 
     private var captureSession: AVCaptureSession?
     private var request: VNCoreMLRequest?
@@ -183,6 +185,8 @@ extension BusDetectionViewController {
         guard let predictions =
             (request.results as? [VNRecognizedObjectObservation])
         else { return }
+
+        var tempDetected: [String] = []
         var finalPredictions: [VNRecognizedObjectObservation] = []
 
         for prediction in predictions {
@@ -207,11 +211,16 @@ extension BusDetectionViewController {
                     if ocrText.contains(routeNo) {
                         // 검사 결과에 있다면 바운딩박스에 추가
                         finalPredictions.append(prediction)
+                        if !tempDetected.contains(routeNo) {
+                            tempDetected.append(routeNo)
+                        }
                     }
                 }
             }
         }
+
         DispatchQueue.main.async {
+            self.onDetectedRouteNumbersChanged?(tempDetected)
             self.drawingBoxesView?.drawBox(with: finalPredictions)
         }
     }

--- a/OffStageApp/Sources/Presentation/BusVision/BusVisionView.swift
+++ b/OffStageApp/Sources/Presentation/BusVision/BusVisionView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct BusVisionView: View {
     // properties
     var routeNumbers: [String]
+    @State var detectedRouteNumbers: [String] = []
 
     @EnvironmentObject var router: Router<AppRoute>
 
@@ -13,9 +14,31 @@ struct BusVisionView: View {
     }
 
     var body: some View {
-        VStack {
-            BusDetectionView(routeNumbers: routeNumbers)
-                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        ZStack(alignment: .bottom) {
+            // 뷰파인더 + 바운딩박스
+            BusDetectionView(
+                routeNumbersToDetect: routeNumbers,
+                detectedRouteNumbers: $detectedRouteNumbers
+            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+
+            // 노선번호 로딩 & 결과
+            VStack {
+                if detectedRouteNumbers.isEmpty {
+                    ProgressView()
+                } else {
+                    Text(detectedRouteNumbers.joined(separator: "& "))
+                        .font(.system(size: 120, weight: .black))
+                        .foregroundStyle(Color.white)
+                        .frame(maxWidth: .infinity, alignment: .center)
+                }
+            }
+            .padding(.vertical)
+            .frame(maxWidth: .infinity, maxHeight: 150, alignment: .center)
+            .background {
+                Rectangle()
+                    .foregroundStyle(.black)
+            }
         }
     }
 }


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #42

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- BusVisionView에 탐지된 노선 번호를 실시간으로 표시하는 기능 추가
- BusDetectionView(SwiftUI <-> UIKit)와 BusVisionView(SwiftUI) 간 양방향 데이터 바인딩 구현
- BusDetectionViewController에서 클로저 기반 업데이트 구조로 탐지 결과 전달
- 버스 탐지 시 즉시 UI에 노선 번호가 반영되도록 개선

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->
 <img width="300" alt="207버스인식해서번호크게" src="https://github.com/user-attachments/assets/b11be4ea-d231-4045-b4f8-ba6df0606c55"> 


---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] 버스 탐지 시 노선 번호가 실시간으로 UI에 표시되는지 확인
- [x] 바인딩이 정상적으로 작동하여 탐지 결과가 즉시 반영되는지 검증
- [x] 여러 버스가 탐지될 때 모든 노선 번호가 정확히 표시되는지 확인

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- 체감상 노선번호를 보여주기 전보다 버스 인식이 잘 안되는 것 같습니다(아직 많은 개선이 필요합니다🥲). 촬영한 영상으로는 한계가 있는 것 같아 직접 앱에서 버스 인식을 진행해봐야 할 시점이 된 것 같습니다!