### PR TITLE
🐛 Fix: #50 노선 번호에서 괄호 및 내용 제거하여 탐지 정확도 개선

### DIFF
--- a/OffStageApp/Sources/Presentation/BusVision/BusVisionView.swift
+++ b/OffStageApp/Sources/Presentation/BusVision/BusVisionView.swift
@@ -17,7 +17,7 @@ struct BusVisionView: View {
         ZStack(alignment: .bottom) {
             // 뷰파인더 + 바운딩박스
             BusDetectionView(
-                routeNumbersToDetect: routeNumbers,
+                routeNumbersToDetect: routeNumbers.map { removeParenthesesContent($0) },
                 detectedRouteNumbers: $detectedRouteNumbers
             )
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
@@ -40,5 +40,14 @@ struct BusVisionView: View {
                     .foregroundStyle(.black)
             }
         }
+    }
+}
+
+extension BusVisionView {
+    private func removeParenthesesContent(_ text: String) -> String {
+        if let range = text.range(of: "\\(.*\\)", options: .regularExpression) {
+            return text.replacingCharacters(in: range, with: "").trimmingCharacters(in: .whitespaces)
+        }
+        return text
     }
 }


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What's this PR?

### 📌 관련 이슈 (Related Issue)
- Closes #50

---

### 🧶 주요 변경 내용 (Summary)

- 노선 번호에서 괄호 및 괄호 안 내용을 제거하는 전처리 로직 추가
- BusDetectionView에 전달되는 노선 번호를 순수 숫자만 포함하도록 정제: "202(기본)" → "202"로 변환하여 탐지할 수 있도록 함

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

https://github.com/user-attachments/assets/6330e988-321d-4820-bebe-ed4973f8c170


---

### 🧪 테스트 / 검증 내역

- [x] 괄호가 포함된 노선 번호("202(간선)", "405(급행)")에서 괄호 제거 정상 동작 확인
- [x] 정제된 노선 번호로 버스 탐지가 정상적으로 수행되는지 검증

---

### 💬 기타 공유 사항

- API나 데이터 소스에서 노선 번호에 부가 정보가 괄호로 포함되어 전달되는 경우가 있어 이를 처리하기 위한 전처리 로직입니다
- OCR 탐지는 순수 노선번호만 인식하므로, 괄호가 포함된 노선 번호는 매칭되지 않아 탐지 실패가 발생했습니다

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)

- BusDetectionView에 전달되기 전 전처리 시점이 올바른지
  - 현재 괄호 제거 로직을 Operations 파일로 빼서 처리하는 게 더 나을지 고민입니다