### PR TITLE
Fix: BusAPI 모듈의 불필요한 Resources 폴더 삭제

### DIFF
--- a/Project.swift
+++ b/Project.swift
@@ -37,7 +37,7 @@ let busAPI = Target.target(
     product: .framework,
     bundleId: "\(organizationName).BusAPI",
     infoPlist: .extendingDefault(with: baseInfoPlist),
-    sources: ["Modules/BusAPI/Sources/**", "Modules/BusAPI/Resources/**"],
+    sources: ["Modules/BusAPI/Sources/**"],
     dependencies: [
         .external(name: "Moya"),
         .external(name: "Logging"),


### PR DESCRIPTION
### 📌 관련 이슈 (Related Issue)
<!-- - Closes #ISSUE_NUMBER (해당하는 이슈 번호가 있다면 여기에 추가) -->

---

### 🧶 주요 변경 내용 (Summary)
- `BusAPI` 모듈에서 더 이상 사용되지 않는 `Resources` 폴더를
삭제했습니다.
- 이로 인해 `tuist generate` 시 발생하던 오류를 해결하고 프로젝트
구조를 정리했습니다.

---

### 🧪 테스트 / 검증 내역
- [x] `tuist generate` 명령이 오류 없이 성공적으로 실행되는지
확인.
- [x] 프로젝트 빌드 및 실행에 문제가 없는지 확인.

---

### 💬 기타 공유 사항
- 이 변경은 `fix/local-stop-search` 브랜치에서 진행된 리팩토링의
후속 조치입니다.