### PR TITLE
♻️ Refactor: #66 앱 타겟 이름 및 번들 ID 변경

### DIFF
--- a/Config/Debug.xcconfig
+++ b/Config/Debug.xcconfig
@@ -1,5 +1,5 @@
 #include "Secrets.xcconfig"
 
 APP_DISPLAY_NAME = OffStage Dev
-PRODUCT_BUNDLE_IDENTIFIER = com.offstage.app.dev
+PRODUCT_BUNDLE_IDENTIFIER = 2025C6.OffStage.App.Dev
 SWIFT_ACTIVE_COMPILATION_CONDITIONS = $(inherited) DEBUG_MODE

--- a/Config/Dev.xcconfig
+++ b/Config/Dev.xcconfig
@@ -1,5 +1,5 @@
 #include "Secrets.xcconfig"
 
 APP_DISPLAY_NAME = OffStage Dev
-PRODUCT_BUNDLE_IDENTIFIER = com.offstage.app.dev
+PRODUCT_BUNDLE_IDENTIFIER =2025C6.OffStage.App.Dev
 SWIFT_ACTIVE_COMPILATION_CONDITIONS = $(inherited) DEBUG_MODE

--- a/Config/Prod.xcconfig
+++ b/Config/Prod.xcconfig
@@ -1,4 +1,4 @@
 #include "Secrets.xcconfig"
 
 APP_DISPLAY_NAME = OffStage
-PRODUCT_BUNDLE_IDENTIFIER = com.offstage.app
+PRODUCT_BUNDLE_IDENTIFIER = 2025C6.OffStage.App

--- a/Config/Release.xcconfig
+++ b/Config/Release.xcconfig
@@ -1,4 +1,4 @@
 #include "Secrets.xcconfig"
 
 APP_DISPLAY_NAME = OffStage
-PRODUCT_BUNDLE_IDENTIFIER = com.offstage.app
+PRODUCT_BUNDLE_IDENTIFIER = 2025C6.OffStage.App

--- a/Project.swift
+++ b/Project.swift
@@ -54,7 +54,7 @@ let busAPITests = Target.target(
     sources: ["Modules/BusAPITests/Sources/**"],
     dependencies: [
         .target(name: "BusAPI"),
-        .target(name: "OffStageApp"),
+        .target(name: "OffStage"),
     ]
 )
 
@@ -66,7 +66,7 @@ let configurations: [Configuration] = [
 ]
 
 let app = Target.target(
-    name: "OffStageApp",
+    name: "OffStage",
     destinations: [.iPhone],
     product: .app,
     bundleId: "$(PRODUCT_BUNDLE_IDENTIFIER)",
@@ -89,14 +89,14 @@ let project = Project(
     targets: [busAPI, busAPITests, app],
     schemes: [
         .scheme(
-            name: "OffStageApp-Dev",
-            buildAction: .buildAction(targets: ["OffStageApp"]),
+            name: "OffStage-Dev",
+            buildAction: .buildAction(targets: ["OffStage"]),
             runAction: .runAction(configuration: .configuration("Debug-Dev")),
             archiveAction: .archiveAction(configuration: .configuration("Release-Dev"))
         ),
         .scheme(
-            name: "OffStageApp",
-            buildAction: .buildAction(targets: ["OffStageApp"]),
+            name: "OffStage",
+            buildAction: .buildAction(targets: ["OffStage"]),
             runAction: .runAction(configuration: .configuration("Debug-Prod")),
             archiveAction: .archiveAction(configuration: .configuration("Release-Prod"))
         ),


### PR DESCRIPTION
## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
- Closes #66

---


### 🧶 주요 변경 내용 (Summary)

- `Project.swift`에서 앱 타겟 이름을 `OffStageApp`에서 `OffStage`로 변경했습니다.
- `Config/*.xcconfig` 파일들의 `PRODUCT_BUNDLE_IDENTIFIER`를 새로운 타겟 이름에 맞게 수정했습니다.
- `OffStage-Dev` 및 `OffStage` 스킴의 이름과 빌드 타겟을 변경된 타겟에 맞게 업데이트했습니다.

---


### 🧪 테스트 / 검증 내역

- [x] `tuist generate` 실행 후 프로젝트가 Xcode에서 정상적으로 열리는지 확인했습니다.
- [x] `OffStage-Dev` 스킴으로 앱을 빌드하고 실행하여 정상 동작하는 것을 확인했습니다.
- [x] `OffStage` 스킴으로 앱을 빌드하고 실행하여 정상 동작하는 것을 확인했습니다.

---


### 🙇🏻‍♀️ 리뷰 가이드 (선택)

- `Project.swift` 파일의 타겟 및 스킴 이름 변경 사항을 확인해주세요.
- 각 `xcconfig` 파일의 `PRODUCT_BUNDLE_IDENTIFIER`가 올바르게 수정되었는지 확인해주세요.