### PR TITLE
✨ Feature: #75 홈 화면 즐겨찾기 편집 기능 구현

### DIFF
--- a/OffStageApp/Sources/Domain/Favorite.swift
+++ b/OffStageApp/Sources/Domain/Favorite.swift
@@ -19,6 +19,7 @@ final class Favorite {
     let routeNo: String
     /// 노선 방향
     let direction: String
+    var order: Int
 
     init(
         cityCode: String,
@@ -27,7 +28,8 @@ final class Favorite {
         routeId: String,
         nodeName: String,
         routeNo: String,
-        direction: String
+        direction: String,
+        order: Int
     ) {
         id = "\(cityCode)-\(nodeId)-\(routeId)"
         self.cityCode = cityCode
@@ -37,5 +39,6 @@ final class Favorite {
         self.nodeName = nodeName
         self.routeNo = routeNo
         self.direction = direction
+        self.order = order
     }
 }

--- a/OffStageApp/Sources/Presentation/BusStation/SubView/BusStationListSubView.swift
+++ b/OffStageApp/Sources/Presentation/BusStation/SubView/BusStationListSubView.swift
@@ -1,8 +1,10 @@
+import SwiftData
 import SwiftUI
 
 struct BusStationListSubView: View {
     let routes: [BusStationViewModel.RouteDetail]
     let viewInput: BusStationViewInput
+    @Query private var favorites: [Favorite]
 
     var body: some View {
         VStack(spacing: 0) {
@@ -12,7 +14,8 @@ struct BusStationListSubView: View {
                     cityCode: viewInput.cityCode,
                     nodeId: viewInput.nodeId,
                     nodeNo: viewInput.nodeNumber,
-                    nodeName: viewInput.nodeName
+                    nodeName: viewInput.nodeName,
+                    isFavorite: isFavorite(routeId: route.routeId)
                 )
                 if route.id != routes.last?.id {
                     Divider()
@@ -22,5 +25,10 @@ struct BusStationListSubView: View {
         .padding()
         .background(Color(.systemGray6))
         .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+    }
+
+    private func isFavorite(routeId: String) -> Bool {
+        let favoriteId = "\(viewInput.cityCode)-\(viewInput.nodeId)-\(routeId)"
+        return favorites.contains { $0.id == favoriteId }
     }
 }

--- a/OffStageApp/Sources/Presentation/BusStation/SubView/BusStationRowSubView.swift
+++ b/OffStageApp/Sources/Presentation/BusStation/SubView/BusStationRowSubView.swift
@@ -14,25 +14,10 @@ struct BusStationRowSubView: View {
     let nodeId: String
     let nodeNo: String?
     let nodeName: String
-
-    @Query private var favorites: [Favorite]
-
-    init(route: BusStationViewModel.RouteDetail, cityCode: String, nodeId: String, nodeNo: String?, nodeName: String) {
-        self.route = route
-        self.cityCode = cityCode
-        self.nodeId = nodeId
-        self.nodeNo = nodeNo
-        self.nodeName = nodeName
-
-        let favoriteId = "\(cityCode)-\(nodeId)-\(route.routeId)"
-        _favorites = Query(filter: #Predicate { $0.id == favoriteId })
-        print(
-            "BusStationRowSubView init: cityCode=\(cityCode), nodeId=\(nodeId), routeId=\(route.routeId), favoriteId=\(favoriteId)"
-        )
-    }
+    let isFavorite: Bool
 
     private var isSavedOn: Bool {
-        !favorites.isEmpty
+        isFavorite
     }
 
     var body: some View {
@@ -66,12 +51,6 @@ struct BusStationRowSubView: View {
                                     Text(remaining)
                                         .foregroundColor(.secondary)
                                 }
-                                /** voice over 라벨링으로 활용
-                                  if let vehicle = arrival.vehicleDescription {
-                                      Text(vehicle)
-                                          .foregroundColor(.secondary)
-                                  }
-                                 */
                             }
                             .font(.footnote)
                         }
@@ -90,7 +69,10 @@ struct BusStationRowSubView: View {
     }
 
     private func addFavorite() {
-        print("Adding favorite: cityCode=\(cityCode), nodeId=\(nodeId), routeId=\(route.routeId)")
+        let fetchDescriptor = FetchDescriptor<Favorite>()
+        let allFavorites = (try? modelContext.fetch(fetchDescriptor)) ?? []
+        let stationCount = Dictionary(grouping: allFavorites, by: { $0.nodeId }).count
+
         let favorite = Favorite(
             cityCode: cityCode,
             nodeId: nodeId,
@@ -98,28 +80,17 @@ struct BusStationRowSubView: View {
             routeId: route.routeId,
             nodeName: nodeName,
             routeNo: route.routeNumber,
-            direction: route.direction
+            direction: route.direction,
+            order: stationCount
         )
         modelContext.insert(favorite)
-        do {
-            try modelContext.save()
-            print("Successfully saved favorite")
-        } catch {
-            print("Failed to save favorite: \(error)")
-        }
+        try? modelContext.save()
     }
 
     private func removeFavorite() {
-        print("Removing favorite: cityCode=\(cityCode), nodeId=\(nodeId), routeId=\(route.routeId)")
-        if let favorite = favorites.first {
-            modelContext.delete(favorite)
-            do {
-                try modelContext.save()
-                print("Successfully removed favorite")
-            } catch {
-                print("Failed to remove favorite: \(error)")
-            }
-        }
+        let favoriteId = "\(cityCode)-\(nodeId)-\(route.routeId)"
+        try? modelContext.delete(model: Favorite.self, where: #Predicate { $0.id == favoriteId })
+        try? modelContext.save()
     }
 }
 
@@ -131,7 +102,8 @@ struct BusStationRowSubView: View {
             cityCode: "25",
             nodeId: "DJB8001793",
             nodeNo: "12345",
-            nodeName: "포항성모병원"
+            nodeName: "포항성모병원",
+            isFavorite: false
         )
         .modelContainer(container)
     } catch {

--- a/OffStageApp/Sources/Presentation/Home/HomeView.swift
+++ b/OffStageApp/Sources/Presentation/Home/HomeView.swift
@@ -24,7 +24,7 @@ struct HomeView: View {
 
     @State private var searchText = ""
     @Query(sort: [
-        SortDescriptor<Favorite>(\Favorite.nodeName),
+        SortDescriptor<Favorite>(\Favorite.order),
         SortDescriptor<Favorite>(\Favorite.routeNo),
     ]) private var favorites: [Favorite]
 
@@ -32,13 +32,7 @@ struct HomeView: View {
         let grouped = Dictionary(grouping: favorites, by: { $0.nodeId })
         return grouped.map { _, favorites in
             FavoritedStop(favorites: favorites)
-        }.sorted {
-            if $0.nodeName != $1.nodeName {
-                $0.nodeName < $1.nodeName
-            } else {
-                $0.nodeId < $1.nodeId
-            }
-        }
+        }.sorted { $0.order < $1.order }
     }
 
     var body: some View {
@@ -162,5 +156,6 @@ extension HomeView {
         var nodeName: String { favorites.first?.nodeName ?? "" }
         var nodeNo: String? { favorites.first?.nodeNo }
         var cityCode: String { favorites.first?.cityCode ?? "" }
+        var order: Int { favorites.first?.order ?? 0 }
     }
 }

--- a/OffStageApp/Sources/Presentation/HomeEdit/HomeEditView.swift
+++ b/OffStageApp/Sources/Presentation/HomeEdit/HomeEditView.swift
@@ -1,46 +1,147 @@
+import SwiftData
 import SwiftUI
 
 struct HomeEditView: View {
     @EnvironmentObject var router: Router<AppRoute>
+    @Environment(\.modelContext) private var modelContext
+    @Query(sort: [
+        SortDescriptor<Favorite>(\Favorite.order),
+        SortDescriptor<Favorite>(\Favorite.routeNo),
+    ]) private var favorites: [Favorite]
+
+    // 취소를 허용하기 위한 데이터의 인메모리 복사본
+    @State private var editableStops: [FavoritedStop] = []
+    // 초기 상태 저장
+    @State private var originalStops: [FavoritedStop] = []
+    @State private var hasChanges = false
+
+    private var favoritedStops: [FavoritedStop] {
+        let grouped = Dictionary(grouping: favorites, by: { $0.nodeId })
+        return grouped.map { _, favorites in
+            FavoritedStop(favorites: favorites)
+        }.sorted { $0.order < $1.order }
+    }
 
     var body: some View {
         VStack {
-            Rectangle()
-                .foregroundColor(.black)
-                .frame(height: 100)
-
-            Text("추후 개발 예정입니다.")
-                .font(.title3)
-                .foregroundColor(.gray)
-
-            Spacer()
-        }
-        .navigationBarBackButtonHidden(true)
-        .toolbar {
-            ToolbarItem(placement: .navigationBarLeading) {
-                Button {
-                    router.pop()
-                } label: {
-                    Image(systemName: "chevron.left")
-                        .foregroundColor(.gray)
+            List {
+                ForEach(editableStops) { station in
+                    HStack {
+                        VStack(alignment: .leading) {
+                            Text(station.nodeName)
+                                .font(.headline)
+                            Text(station.nodeNo ?? "")
+                                .font(.subheadline)
+                                .foregroundColor(.gray)
+                            Text(station.favorites.map(\.routeNo).joined(separator: ", "))
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                        Spacer()
+                    }
                 }
+                .onDelete(perform: deleteStations)
+                .onMove(perform: moveStations)
             }
+            .environment(\.editMode, .constant(.active))
 
+            footerButtons
+        }
+        .onAppear(perform: setupInitialState)
+        .toolbar {
             ToolbarItem(placement: .principal) {
-                VStack {
-                    Text("홈 화면 편집")
-                        .font(.title2)
-                        .foregroundColor(.gray)
-                }
-                .frame(height: 400)
+                Text("홈 화면 편집")
+                    .font(.title2)
             }
         }
         .navigationBarTitleDisplayMode(.inline)
-        .toolbarBackground(.visible, for: .navigationBar)
+    }
+
+    private var footerButtons: some View {
+        HStack(spacing: 12) {
+            Button(action: cancelChanges) {
+                Text("취소")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.bordered)
+
+            Button(action: saveChanges) {
+                Text("저장")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(!hasChanges)
+        }
+        .padding()
+    }
+
+    private func setupInitialState() {
+        // 영구 저장된 데이터를 편집 가능한 상태로 한 번만 로드
+        if editableStops.isEmpty {
+            editableStops = favoritedStops
+            originalStops = favoritedStops // 초기 상태 저장
+        }
+    }
+
+    private func cancelChanges() {
+        editableStops = originalStops // 원래 상태로 되돌리기
+        hasChanges = false // 저장할 변경 사항 없음
+        // router.pop()
+    }
+
+    private func deleteStations(at offsets: IndexSet) {
+        editableStops.remove(atOffsets: offsets)
+        hasChanges = true
+    }
+
+    private func moveStations(from source: IndexSet, to destination: Int) {
+        editableStops.move(fromOffsets: source, toOffset: destination)
+        hasChanges = true
+    }
+
+    private func saveChanges() {
+        // 편집 가능한 목록에 아직 있는 노드 ID 집합 생성
+        let finalNodeIDs = Set(editableStops.map(\.nodeId))
+
+        // 목록에 더 이상 없는 즐겨찾기 삭제
+        for favorite in favorites {
+            if !finalNodeIDs.contains(favorite.nodeId) {
+                modelContext.delete(favorite)
+            }
+        }
+
+        // 나머지 즐겨찾기의 순서 업데이트
+        for (index, station) in editableStops.enumerated() {
+            for favorite in station.favorites {
+                favorite.order = index
+            }
+        }
+
+        // 변경사항 저장 및 뷰 닫기
+        try? modelContext.save()
+        router.pop()
+    }
+}
+
+extension HomeEditView {
+    // 재정렬을 위해 이 구조체는 변경 가능해야함.
+    struct FavoritedStop: Identifiable {
+        var favorites: [Favorite]
+        var id: String { (favorites.first?.nodeId ?? "") + favorites.map(\.id).joined() }
+        var nodeId: String { favorites.first?.nodeId ?? "" }
+        var nodeName: String { favorites.first?.nodeName ?? "" }
+        var nodeNo: String? { favorites.first?.nodeNo }
+        var cityCode: String { favorites.first?.cityCode ?? "" }
+        var order: Int { favorites.first?.order ?? 0 }
     }
 }
 
 #Preview {
-    // 미리보기용 Mock Router
-    RouterView(router: Router<AppRoute>(root: .homeedit))
+    do {
+        let container = try ModelContainer(for: Favorite.self, configurations: .init(isStoredInMemoryOnly: true))
+        return RouterView(router: Router<AppRoute>(root: .homeedit))
+            .modelContainer(container)
+    } catch {
+        return Text("Failed to create preview: \(error.localizedDescription)")
+    }
 }


### PR DESCRIPTION
## ✨ What’s this PR?

### 📌 관련 이슈 (Related Issue)

- Closes #75

---

### 🧶 주요 변경 내용 (Summary)

- 홈 화면의 즐겨찾기 목록을 사용자가 직접 편집할 수 있는 기능을 추가했습니다.
- `Favorite` 모델에 `order` 프로퍼티를 추가하여 즐겨찾기 순서를 저장합니다.
- `HomeEditView`에서 드래그 앤 드롭으로 순서를 변경하고, 스와이프로 삭제할 수 있습니다.

---

### 📸 스크린샷 (Optional)

<img width="300" alt="Simulator Screenshot - iPhone 16 - 2025-11-02 at 20 09 16" src="https://github.com/user-attachments/assets/ece00c48-d5f7-479a-99b5-212c69bc2cff" />

---

### 🧪 테스트 / 검증 내역

- [x] 홈 화면에서 '편집' 버튼을 눌러 편집 화면으로 이동하는지 확인
- [x] 드래그 앤 드롭으로 순서 변경 후 '저장' 시 홈 화면에 반영되는지 확인
- [x] 스와이프로 항목 삭제 후 '저장' 시 홈 화면에 반영되는지 확인
- [x] '취소' 버튼을 눌렀을 때 변경 사항이 저장되지 않는지 확인