### PR TITLE
✨ Feature: #74 신규 사용자를 위한 온보딩 화면 구현

### DIFF
--- a/OffStageApp/Sources/OffStageApp.swift
+++ b/OffStageApp/Sources/OffStageApp.swift
@@ -33,7 +33,16 @@ import SwiftUI
 
 @main
 struct OffStageApp: App {
-    @StateObject private var router = Router<AppRoute>(root: .home)
+    @StateObject private var router: Router<AppRoute>
+
+    init() {
+        #if DEBUG_MODE
+            _router = StateObject(wrappedValue: Router(root: .onboarding))
+        #else
+            let hasLaunchedBefore = UserDefaults.standard.bool(forKey: "hasLaunchedBefore")
+            _router = StateObject(wrappedValue: Router(root: hasLaunchedBefore ? .home : .onboarding))
+        #endif
+    }
 
     var body: some Scene {
         WindowGroup {

--- a/OffStageApp/Sources/Presentation/BusStation/BusStationViewModel.swift
+++ b/OffStageApp/Sources/Presentation/BusStation/BusStationViewModel.swift
@@ -147,7 +147,7 @@ extension BusStationViewModel.RouteDetail {
     )
 }
 
-#if DEBUG
+#if DEBUG_MODE
     extension BusStationViewModel {
         func applyPreviewState(_ state: ViewState) {
             viewState = state

--- a/OffStageApp/Sources/Presentation/Onboarding/OnboardingPermissionsView.swift
+++ b/OffStageApp/Sources/Presentation/Onboarding/OnboardingPermissionsView.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+
+struct OnboardingPermissionsView: View {
+    var onNext: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Spacer()
+            Text("권한 허용")
+                .font(.largeTitle)
+                .fontWeight(.bold)
+
+            Text("앱을 이용하기 위해\n다음 권한의 허용이 필요합니다.")
+                .font(.title2)
+                .padding(.bottom, 40)
+
+            PermissionRow(title: "알림 (필수)", description: "버스 도착 알림 정보 제공")
+            PermissionRow(title: "위치 정보 (필수)", description: "사용자 위치 기반 위치 정보 제공")
+            PermissionRow(title: "카메라 (필수)", description: "버스 번호 인식 정보 제공")
+            PermissionRow(title: "마이크 (선택)", description: "사용자 위치 기반 위치 정보 제공")
+
+            Spacer()
+
+            Text("탑승할 버스 번호판을 구별하여\n저시력자가 스스로 버스를 탈 수\n있게 돕습니다.")
+                .font(.title2)
+                .multilineTextAlignment(.center)
+                .foregroundColor(.gray)
+                .frame(maxWidth: .infinity, alignment: .center)
+
+            Button("다음") {
+                onNext()
+            }
+            .font(.headline)
+            .foregroundColor(.black)
+            .frame(maxWidth: .infinity)
+            .padding()
+            .background(Color.white)
+            .cornerRadius(10)
+            .padding()
+        }
+        .padding()
+    }
+}
+
+struct PermissionRow: View {
+    let title: String
+    let description: String
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text(title)
+                .font(.headline)
+            Text(description)
+                .font(.subheadline)
+                .foregroundColor(.gray)
+        }
+        .padding(.bottom, 20)
+    }
+}

--- a/OffStageApp/Sources/Presentation/Onboarding/OnboardingView.swift
+++ b/OffStageApp/Sources/Presentation/Onboarding/OnboardingView.swift
@@ -2,26 +2,31 @@ import SwiftUI
 
 struct OnboardingView: View {
     @EnvironmentObject var router: Router<AppRoute>
+    @State private var tabSelection = 0
 
     var body: some View {
-        VStack(spacing: 16) {
-            Text("온보딩 권한요청 화면")
-                .font(.largeTitle)
+        VStack {
+            TabView(selection: $tabSelection) {
+                OnboardingWelcomeView {
+                    tabSelection = 1
+                }
+                .tag(0)
 
-            Button("이전 화면으로 돌아가기 (pop)") {
-                router.pop()
+                OnboardingPermissionsView {
+                    // '다음' 버튼을 누르면 온보딩 완료 플래그를 설정하고 홈 화면으로 이동합니다.
+                    UserDefaults.standard.set(true, forKey: "hasLaunchedBefore")
+                    router.root = .home
+                }.tag(1)
             }
-
-            Button("홈으로 돌아가기 (popToRoot)") {
-                router.popToRoot()
-            }
+            .tabViewStyle(.page(indexDisplayMode: .never))
         }
-        .padding()
         .navigationTitle("Onboarding")
+        .navigationBarHidden(true)
+        .background(Color.black.ignoresSafeArea())
+        .foregroundColor(.white)
     }
 }
 
 #Preview {
-    // 미리보기용 Mock Router
     RouterView(router: Router<AppRoute>(root: .onboarding))
 }

--- a/OffStageApp/Sources/Presentation/Onboarding/OnboardingWelcomeView.swift
+++ b/OffStageApp/Sources/Presentation/Onboarding/OnboardingWelcomeView.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+struct OnboardingWelcomeView: View {
+    var onStart: () -> Void
+
+    var body: some View {
+        VStack {
+            Spacer()
+            Text("저시력 시각장애인을 위한\n버스 안내 앱입니다.")
+                .font(.largeTitle)
+                .fontWeight(.bold)
+                .multilineTextAlignment(.center)
+
+            Image(systemName: "photo")
+                .resizable()
+                .scaledToFit()
+                .frame(width: 200, height: 200)
+                .padding()
+
+            Text("탑승할 버스 번호판을 구별하여\n저시력자가 스스로 버스를 탈 수\n있게 돕습니다.")
+                .font(.title2)
+                .multilineTextAlignment(.center)
+                .foregroundColor(.gray)
+
+            Spacer()
+
+            Button("시작하기") {
+                onStart()
+            }
+            .font(.headline)
+            .foregroundColor(.black)
+            .frame(maxWidth: .infinity)
+            .padding()
+            .background(Color.white)
+            .cornerRadius(10)
+            .padding()
+        }
+    }
+}


### PR DESCRIPTION
## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
- Closes #74

---

### 🧶 주요 변경 내용 (Summary)
- 앱 최초 실행 시 온보딩 화면을 표시하여 앱의 주요 기능을 안내합니다.
- `UserDefaults`를 사용하여 앱 최초 실행 여부를 확인하고, 최초 실행 시에만 온보딩이 표시되도록 구현했습니다.
- `DEBUG_MODE`에서는 항상 온보딩 화면이 표시되도록 하여 테스트 편의성을 높였습니다.

---

### 📸 스크린샷 (Optional)
|                                Onboarding Welcome                                 |                              Onboarding Permissions                               |
| :-------------------------------------------------------------------------------: | :-------------------------------------------------------------------------------: |
| ![image](https://github.com/user-attachments/assets/838eefe6-c121-443a-a1db-9401698165a2) | ![image](https://github.com/user-attachments/assets/832765bc-575e-493f-a3eb-94485c52e961) |

---

### 🧪 테스트 / 검증 내역
- [x] 앱 최초 실행 시 온보딩 화면 표시 확인
- [x] 온보딩 완료 후 앱을 재시작했을 때 홈 화면이 표시되는지 확인
- [x] `DEBUG_MODE`에서 앱을 재시작했을 때 항상 온보딩 화면이 표시되는지 확인