### PR TITLE
🎨 Design: #81 즐겨찾기 편집 디자인 반영

### DIFF
--- a/OffStageApp/Sources/Presentation/HomeEdit/HomeEditView.swift
+++ b/OffStageApp/Sources/Presentation/HomeEdit/HomeEditView.swift
@@ -23,56 +23,32 @@ struct HomeEditView: View {
     }
 
     var body: some View {
-        VStack {
+        VStack(spacing: 0) {
             List {
                 ForEach(editableStops) { station in
-                    HStack {
-                        VStack(alignment: .leading) {
-                            Text(station.nodeName)
-                                .font(.headline)
-                            Text(station.nodeNo ?? "")
-                                .font(.subheadline)
-                                .foregroundColor(.gray)
-                            Text(station.favorites.map(\.routeNo).joined(separator: ", "))
-                                .font(.caption)
-                                .foregroundColor(.secondary)
-                        }
-                        Spacer()
-                    }
+                    HomeEditListRowView(
+                        nodeName: station.nodeName,
+                        nodeNo: station.nodeNo,
+                        routes: station.favorites.map(\.routeNo),
+                    )
                 }
                 .onDelete(perform: deleteStations)
                 .onMove(perform: moveStations)
             }
+            .listStyle(.plain)
             .environment(\.editMode, .constant(.active))
 
-            footerButtons
+            HomeEditFooterButtomsView(
+                isSaveBtnDisabled: !hasChanges,
+                cancelChanges: cancelChanges,
+                saveChanges: saveChanges
+            )
+            .padding(.vertical, 4)
+            .padding(.horizontal, 20)
         }
         .onAppear(perform: setupInitialState)
-        .toolbar {
-            ToolbarItem(placement: .principal) {
-                Text("홈 화면 편집")
-                    .font(.title2)
-            }
-        }
         .navigationBarTitleDisplayMode(.inline)
-    }
-
-    private var footerButtons: some View {
-        HStack(spacing: 12) {
-            Button(action: cancelChanges) {
-                Text("취소")
-                    .frame(maxWidth: .infinity)
-            }
-            .buttonStyle(.bordered)
-
-            Button(action: saveChanges) {
-                Text("저장")
-                    .frame(maxWidth: .infinity)
-            }
-            .buttonStyle(.borderedProminent)
-            .disabled(!hasChanges)
-        }
-        .padding()
+        .navigationTitle("즐겨찾기 편집")
     }
 
     private func setupInitialState() {

--- a/OffStageApp/Sources/Presentation/HomeEdit/SubView/HomeEditFooterButtomsView.swift
+++ b/OffStageApp/Sources/Presentation/HomeEdit/SubView/HomeEditFooterButtomsView.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+
+struct HomeEditFooterButtomsView: View {
+    let isSaveBtnDisabled: Bool
+    let cancelChanges: () -> Void
+    let saveChanges: () -> Void
+
+    // todo - 아래 색상 primary 등록하면 바꾸기
+    let sematicPrimaryNormal = Color(red: 0.9, green: 1, blue: 0)
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Button(action: cancelChanges) {
+                Text("취소")
+                    .font(.title3)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(.white)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 10)
+                    .background {
+                        RoundedRectangle(cornerRadius: 12)
+                            .stroke(Color.gray, lineWidth: 2)
+                    }
+            }
+
+            Button(action: saveChanges) {
+                Text("저장")
+                    .font(.title3)
+                    .fontWeight(.semibold)
+                    .foregroundStyle(
+                        isSaveBtnDisabled
+                            ? Color.white
+                            : .black
+                    )
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 10)
+                    .background {
+                        RoundedRectangle(cornerRadius: 12)
+                            .foregroundStyle(
+                                isSaveBtnDisabled
+                                    ? Color.gray
+                                    : sematicPrimaryNormal
+                            )
+                    }
+            }
+            .disabled(isSaveBtnDisabled)
+        }
+    }
+}
+
+#Preview {
+    HomeEditFooterButtomsView(
+        isSaveBtnDisabled: false,
+        cancelChanges: {},
+        saveChanges: {}
+    )
+}

--- a/OffStageApp/Sources/Presentation/HomeEdit/SubView/HomeEditListRowView.swift
+++ b/OffStageApp/Sources/Presentation/HomeEdit/SubView/HomeEditListRowView.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+struct HomeEditListRowView: View {
+    let nodeName: String
+    let nodeNo: String?
+    let routes: [String]
+
+    // 색상팔레트 나오면 다음상수 없애고 지정하기
+    let tertiary = Color(red: 0.73, green: 0.74, blue: 0.78)
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(nodeName)
+                    .font(.title3)
+                    .fontWeight(.semibold)
+
+                Text(nodeNo ?? "")
+                    .font(.callout)
+                    .foregroundColor(.gray)
+
+                HStack(alignment: .center, spacing: 4) {
+                    Image(systemName: "bus.fill")
+                        .font(.footnote)
+                        .foregroundStyle(tertiary)
+
+                    Text(routes.joined(separator: ", "))
+                        .font(.subheadline)
+                        .fontWeight(.semibold)
+                        .foregroundColor(tertiary)
+                        .lineLimit(1)
+                }
+            }
+
+            Spacer()
+        }
+    }
+}
+
+#Preview {
+    HomeEditListRowView(nodeName: "생명공학연구소", nodeNo: "299002", routes: ["207", "306"])
+}


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #81

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- HomeEditView 하이파이 디자인 적용
- 서브뷰 컴포넌트로 분리

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

다이나믹 텍스트 적용했을 때(디버그 버전이라 우측하단에 플로팅 버튼이 있습니다. 기본 버전에서는 안됨)
<img width="200" alt="image" src="https://github.com/user-attachments/assets/9633eb54-d6b3-4eb5-98b5-20ef7835b8b8" />
다이나믹 텍스트 가장 큰 버전 적용
<img width="200" alt="image" src="https://github.com/user-attachments/assets/216b7cbb-38c5-483d-a152-a2748d13d9f0" />


---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] UI 정상동작 확인
- [x] 다이나믹 텍스트 적용 시에도 반응형 텍스트 적용되는지 확인

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- 색상팔레트가 아직 확정되지 않아서 임시 todo 주석으로 상수 만들어서 적용해두었습니다. 색상을 많이 만들어 둘수록 변경하는 데 힘들 것 같아서 일부만 추가해서 사용하고 대부분 기본 색상을 사용했습니다. 추후 색상 확정되면 바로 삭제하고 적용하겠습니다.