### PR TITLE
✨ Feat: #89 버스 번호 TTS 도입

### DIFF
--- a/OffStageApp/Sources/Infrastructure/TTSManager.swift
+++ b/OffStageApp/Sources/Infrastructure/TTSManager.swift
@@ -5,8 +5,12 @@ import Foundation
 final class TTSManager: NSObject, ObservableObject {
     // MARK: - 공개 상태 (View에서 바인딩)
 
-    @Published var inputText: String = "" // 사용자가 입력한 텍스트
     @Published var selectedLanguage: String = "ko-KR" // 언어 고정: 한국어
+
+    /// 재생 예정인 텍스트 큐
+    private var speechQueue: [String] = []
+    /// 최대 큐 크기 설정
+    private let maxQueueSize: Int = 5
 
     // MARK: - 내부 오디오/합성기
 
@@ -43,29 +47,45 @@ final class TTSManager: NSObject, ObservableObject {
     private func makeUtterance(from text: String) -> AVSpeechUtterance {
         let u = AVSpeechUtterance(string: text)
         u.voice = AVSpeechSynthesisVoice(language: selectedLanguage)
-        // 필요 시 전/후반 딜레이 등:
-        // u.preUtteranceDelay = 0.0
-        // u.postUtteranceDelay = 0.0
+        u.rate = 0.6
+
         return u
     }
 
     // MARK: - 공개 동작 API (View에서 호출)
 
-    /// 입력 텍스트를 즉시 읽기 시작 (기존 재생 중이던 음성 중단 후 재생)
-    func speakNow() {
-        guard !inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+    /// 입력 텍스트 읽기 (기존 재생 중이던 음성에 이어서 재생)
+    func speakNow(of text: String) {
+        let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard !trimmedText.isEmpty else {
             print("읽을 텍스트가 없습니다.")
             return
         }
-        stop() // 기존 재생 상태 초기화
-        let utterance = makeUtterance(from: inputText)
+
+        // 이미 큐에 있는지 확인
+        if speechQueue.contains(trimmedText) {
+            print("이미 재생 예정인 텍스트입니다: \(trimmedText)")
+            return
+        }
+
+        // 큐가 가득 찼는지 확인
+        guard speechQueue.count < maxQueueSize else {
+            print("TTS 큐가 가득 참 (현재: \(speechQueue.count)/\(maxQueueSize))")
+            return
+        }
+
+        speechQueue.append(trimmedText)
+        let utterance = makeUtterance(from: trimmedText)
         synthesizer.speak(utterance)
+        print("TTS 큐에 추가됨 (큐 크기: \(speechQueue.count)): \(trimmedText)")
     }
 
     /// 완전 정지(현재 발화를 즉시 멈춘다)
     func stop() {
         if synthesizer.isSpeaking || synthesizer.isPaused {
             synthesizer.stopSpeaking(at: .immediate)
+            speechQueue.removeAll()
         }
     }
 }
@@ -81,6 +101,10 @@ extension TTSManager: AVSpeechSynthesizerDelegate {
     /// 한 문장의 합성이 완료되면 콘솔로 알린다.
     func speechSynthesizer(_: AVSpeechSynthesizer, didFinish _: AVSpeechUtterance) {
         print("TTS 재생 완료.")
+
+        if !speechQueue.isEmpty {
+            speechQueue.removeFirst()
+        }
     }
 
     /// 합성 과정에서 오류가 발생하면 콘솔에 메시지를 출력한다.

--- a/OffStageApp/Sources/Presentation/BusVision/BusDetectionViewController.swift
+++ b/OffStageApp/Sources/Presentation/BusVision/BusDetectionViewController.swift
@@ -12,6 +12,7 @@ final class BusDetectionViewController: UIViewController {
     private var captureSession: AVCaptureSession?
     private var request: VNCoreMLRequest?
     var impactFeedbackGenerator: UIImpactFeedbackGenerator?
+    private var ttsManager: TTSManager = .init()
 
     private var drawingBoxesView: DrawingBoxesView?
     #if DEBUG_MODE
@@ -181,7 +182,13 @@ extension BusDetectionViewController: AVCaptureVideoDataOutputSampleBufferDelega
                         DispatchQueue.main.async {
                             self.onDetectedRouteNumbersChanged?(fullFrameDetected)
                         }
+                        // tts
+                        guard let firstBusDetected = fullFrameDetected.first else {
+                            return
+                        }
+                        self.ttsManager.speakNow(of: firstBusDetected)
 
+                        // 햅틱
                         self.impactFeedbackGenerator = UIImpactFeedbackGenerator(style: .light)
                         self.impactFeedbackGenerator?.impactOccurred()
 

--- a/OffStageApp/Sources/Presentation/Common/STTandTTSTestView.swift
+++ b/OffStageApp/Sources/Presentation/Common/STTandTTSTestView.swift
@@ -7,6 +7,7 @@ struct STTandTTSTestView: View {
     @StateObject private var speechRecognizer = STTManager()
     @StateObject private var vm = TTSManager()
     @FocusState private var isTextEditorFocused: Bool // 키보드 내리기위한 값.
+    @State private var ttsText: String = ""
 
     var body: some View {
         VStack(alignment: .leading, spacing: 20) {
@@ -40,8 +41,9 @@ struct STTandTTSTestView: View {
             }) {
                 // 상태에 따라 라벨 토글
                 Text(speechRecognizer.isListening ? L10n.SttTtsTest.Ui.buttonStopListening : L10n.SttTtsTest.Ui
-                    .buttonStartListening)
-                    .frame(maxWidth: .infinity)
+                    .buttonStartListening
+                )
+                .frame(maxWidth: .infinity)
             }
             .buttonStyle(.borderedProminent) // 눈에 띄는 기본 버튼 스타일
         }
@@ -53,7 +55,7 @@ struct STTandTTSTestView: View {
                 Text(L10n.SttTtsTest.Ui.titleTts)
                     .font(.caption)
                     .foregroundStyle(.secondary)
-                TextField(L10n.SttTtsTest.Ui.placeholderTts, text: $vm.inputText)
+                TextField(L10n.SttTtsTest.Ui.placeholderTts, text: $ttsText)
                     .frame(maxWidth: .infinity)
                     .padding(8)
                     .overlay(RoundedRectangle(cornerRadius: 12).stroke(.gray.opacity(0.3)))
@@ -67,7 +69,7 @@ struct STTandTTSTestView: View {
 
             HStack {
                 Button(L10n.SttTtsTest.Ui.buttonRead) {
-                    vm.speakNow()
+                    vm.speakNow(of: ttsText)
                 }
                 .buttonStyle(.borderedProminent)
 


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What's this PR?

### 📌 관련 이슈 (Related Issue)
- Closes #89

---

### 🧶 주요 변경 내용 (Summary)

- 버스 탐지 시 노선 번호를 음성으로 안내하는 TTS 기능 추가
- TTSManager API 리팩토링: inputText 프로퍼티 제거 및 speakNow 파라미터 방식으로 변경
- TTSManager에 음성 큐 시스템 도입으로 연속 안내 관리 개선
- BusDetectionViewController에 TTSManager 통합하여 실시간 음성 안내 구현
- STTandTTSTestView를 변경된 TTSManager API에 맞게 업데이트

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

https://github.com/user-attachments/assets/c451ba4e-bbec-422e-89e1-93adf5d8095a


---

### 🧪 테스트 / 검증 내역

- [x] 버스 탐지 성공 시 노선 번호가 음성으로 정상 안내되는지 확인
- [x] 한 버스가 연속으로 감지될 때 음성이 중복으로 계속 큐에 쌓이지 않는지 검증
- [x] STTandTTSTestView에서 변경된 API로 TTS가 정상 작동하는지 확인
- [x] 음성 안내가 중복되지 않고 적절한 타이밍에 재생되는지 테스트

---

### 💬 기타 공유 사항

**🔊 음성 큐 시스템:**
- 최대 크기 제한을 두어 이미 지나간지 한참된 버스의 노선 번호는 음성 안내하지 않도록 처리했습니다
- 이를 통해 사용자가 카메라에 버스가 없을 때에도 이미 지나갔을 때 잡힌 번호 안내(불필요한 음성 안내)로 인한 혼란을 방지합니다

**🔧 API 개선:**
- inputText 프로퍼티를 제거하고 speakNow가 파라미터로 텍스트를 받도록 변경하여 상태 관리를 단순화했습니다
- 이로 인해 TTSManager의 재사용성이 높아지고, 다양한 컨텍스트에서 유연하게 사용할 수 있습니다

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)

- `TTSManager`의 음성 큐 시스템 구현 및 최대 크기 제한 로직
- 음성안내 속도가 적절한지