### PR TITLE
♻️ Refactor: #108 임시 적용된 Presentation 레이어의 A11y 코드 일괄 제거

### DIFF
--- a/OffStageApp/Sources/Presentation/BusStation/BusStationView.swift
+++ b/OffStageApp/Sources/Presentation/BusStation/BusStationView.swift
@@ -74,7 +74,6 @@ struct BusStationView: View {
                 Button(action: { router.popToRoot() }) {
                     Image(systemName: "house")
                 }
-                .accessibilityLabel(Text(L10n.Common.A11y.buttonHome))
             )
 
             RefreshButton(countdown: countdown, rotationAngle: $rotationAngle) {

--- a/OffStageApp/Sources/Presentation/BusStation/SubView/CircularToggleButton.swift
+++ b/OffStageApp/Sources/Presentation/BusStation/SubView/CircularToggleButton.swift
@@ -28,6 +28,5 @@ struct CircularToggleButton: View {
                     .font(.system(size: 24, weight: .regular))
             }
         }
-        .accessibilityLabel(Text(L10n.Common.A11y.buttonToggleFavorite))
     }
 }

--- a/OffStageApp/Sources/Presentation/Common/L10n.swift
+++ b/OffStageApp/Sources/Presentation/Common/L10n.swift
@@ -34,20 +34,6 @@ enum L10n {
     }
 
     enum Common {
-        enum A11y {
-            /// "삭제" (문맥: A11y: 공용: 삭제 액션 이름 (2단계에서 추가했다면 생략))
-            static let actionDelete = key("common.a11y.action.delete")
-
-            /// "홈으로 이동" (문맥: A11y: 홈으로 이동 버튼)
-            static let buttonHome = key("common.a11y.button.home")
-
-            /// "새로고침" (문맥: A11y: 새로고침 버튼의 VoiceOver 레이블)
-            static let buttonRefresh = key("common.a11y.button.refresh")
-
-            /// "즐겨찾기 토글" (문맥: A11y: 즐겨찾기 상태를 토글하는 버튼)
-            static let buttonToggleFavorite = key("common.a11y.button.toggleFavorite")
-        }
-
         enum Ui {
             /// "취소" (문맥: 공용: 취소 버튼)
             static let buttonCancel = key("common.ui.button.cancel")
@@ -86,11 +72,6 @@ enum L10n {
     }
 
     enum Home {
-        enum A11y {
-            /// "빠른 카메라" (문맥: A11y: 빠른 카메라 버튼)
-            static let buttonQuickCamera = key("home.a11y.button.quickCamera")
-        }
-
         enum Ui {
             /// "편집" (문맥: 홈 화면: 편집 버튼)
             static let buttonEdit = key("home.ui.button.edit")
@@ -113,32 +94,6 @@ enum L10n {
     }
 
     enum HomeEdit {
-        enum A11y {
-            /// "아래로 이동" (문맥: A11y: 편집 목록 항목을 아래로 이동시키는 액션 이름)
-            static let actionMoveDown = key("homeEdit.a11y.action.moveDown")
-
-            /// "위로 이동" (문맥: A11y: 편집 목록 항목을 위로 이동시키는 액션 이름)
-            static let actionMoveUp = key("homeEdit.a11y.action.moveUp")
-
-            /// "항목이 삭제되었습니다." (문맥: A11y: 즐겨찾기 항목 삭제 완료 시 음성 알림)
-            static let announceItemDeleted = key("homeEdit.a11y.announce.itemDeleted")
-
-            /// "항목이 아래로 이동했습니다." (문맥: A11y: 항목 순서 아래로 이동 완료 시 음성 알림)
-            static let announceItemMovedDown = key("homeEdit.a11y.announce.itemMovedDown")
-
-            /// "항목이 위로 이동했습니다." (문맥: A11y: 항목 순서 위로 이동 완료 시 음성 알림)
-            static let announceItemMovedUp = key("homeEdit.a11y.announce.itemMovedUp")
-
-            /// "변경 사항이 저장되었습니다." (문맥: A11y: 편집 완료(저장) 버튼 탭 시 음성 알림)
-            static let announceSaved = key("homeEdit.a11y.announce.saved")
-
-            /// "즐겨찾기 목록" (문맥: A11y: HomeEditView의 목록 헤더 (TestView의 헤더와 구별))
-            static let header = key("homeEdit.a11y.header")
-
-            /// "편집 가능한 항목입니다. 쓸어올리거나 내려서 삭제 또는 순서 변경 동작을 실행하십시오." (문맥: A11y: 편집 목록의 각 행에 대한 힌트)
-            static let rowHint = key("homeEdit.a11y.row.hint")
-        }
-
         enum Ui {
             /// "즐겨찾기 편집" (문맥: 즐겨찾기 편집: 내비게이션 타이틀)
             static let title = key("homeEdit.ui.title")
@@ -263,14 +218,6 @@ enum L10n {
     }
 
     enum Test {
-        enum A11y {
-            /// "버스 정보" (문맥: A11y: TestView의 '버스 정보' 섹션 헤더)
-            static let headerBusInfo = key("test.a11y.header.busInfo")
-
-            /// "기기 정보" (문맥: A11y: TestView의 '기기 정보' 섹션 헤더)
-            static let headerDeviceInfo = key("test.a11y.header.deviceInfo")
-        }
-
         enum Ui {
             /// "정류장 기준 전체 도착 예정 정보" (문맥: 테스트: 정류장 도착 정보 버튼 서브타이틀)
             static let buttonArrivalsSubtitle = key("test.ui.button.arrivals.subtitle")

--- a/OffStageApp/Sources/Presentation/Common/RefreshButton.swift
+++ b/OffStageApp/Sources/Presentation/Common/RefreshButton.swift
@@ -32,7 +32,6 @@ struct RefreshButton: View {
                 }
             }
         }
-        .accessibilityLabel(Text(L10n.Common.A11y.buttonRefresh))
     }
 }
 

--- a/OffStageApp/Sources/Presentation/Home/HomeView.swift
+++ b/OffStageApp/Sources/Presentation/Home/HomeView.swift
@@ -59,7 +59,6 @@ struct HomeView: View {
                             .foregroundColor(.gray)
                             .padding(.trailing)
                     }
-                    .accessibilityLabel(Text(L10n.Home.A11y.buttonQuickCamera))
                 }
                 .background(.gray.opacity(0.1))
 

--- a/OffStageApp/Sources/Presentation/HomeEdit/HomeEditView.swift
+++ b/OffStageApp/Sources/Presentation/HomeEdit/HomeEditView.swift
@@ -1,4 +1,3 @@
-import Accessibility // Added for UIAccessibility
 import SwiftData
 import SwiftUI
 
@@ -108,16 +107,6 @@ struct HomeEditView: View {
         // 변경사항 저장 및 뷰 닫기
         try? modelContext.save()
         router.pop()
-
-        // --- ⬇️ A11y 4단계 전략 적용 ⬇️ ---
-        // 2. 실행 결과를 음성으로 알림
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            UIAccessibility.post(
-                notification: .announcement,
-                argument:
-                L10n.HomeEdit.A11y.announceSaved
-            )
-        }
     }
 }
 

--- a/OffStageApp/Sources/Presentation/HomeEdit/SubView/HomeEditListRowView.swift
+++ b/OffStageApp/Sources/Presentation/HomeEdit/SubView/HomeEditListRowView.swift
@@ -1,13 +1,9 @@
-import Accessibility // Added for UIAccessibility
 import SwiftUI
 
 struct HomeEditListRowView: View {
     let nodeName: String
     let nodeNo: String?
     let routes: [String]
-    var onDelete: (() -> Void)? // Added onDelete closure
-    var onMoveUp: (() -> Void)? // Added onMoveUp closure
-    var onMoveDown: (() -> Void)? // Added onMoveDown closure
 
     // 색상팔레트 나오면 다음상수 없애고 지정하기
     let tertiary = Color(red: 0.73, green: 0.74, blue: 0.78)
@@ -38,36 +34,6 @@ struct HomeEditListRowView: View {
 
             Spacer()
         }
-        .accessibilityElement(children: .ignore) // Apply to the main HStack
-        .accessibilityLabel(Text("\(nodeName) 정류장")) // Example label
-        .accessibilityHint(Text(L10n.HomeEdit.A11y.rowHint))
-        .accessibilityAction(named: Text(L10n.Common.A11y.actionDelete)) {
-            onDelete?()
-            // --- ⬇️ A11y 4단계 전략 적용 ⬇️ ---
-            // 2. 실행 결과를 음성으로 알림
-            announce(L10n.HomeEdit.A11y.announceItemDeleted)
-        }
-        .accessibilityAction(named: Text(L10n.HomeEdit.A11y.actionMoveUp)) { // Changed to .string
-            onMoveUp?()
-            // --- ⬇️ A11y 4단계 전략 적용 ⬇️ ---
-            // 2. 실행 결과를 음성으로 알림
-            announce(L10n.HomeEdit.A11y.announceItemMovedUp)
-        }
-        .accessibilityAction(named: Text(L10n.HomeEdit.A11y.actionMoveDown)) { // Changed to .string
-            onMoveDown?()
-            // --- ⬇️ A11y 4단계 전략 적용 ⬇️ ---
-            // 2. 실행 결과를 음성으로 알림
-            announce(L10n.HomeEdit.A11y.announceItemMovedDown)
-        }
-    }
-
-    // --- ⬇️ Helper 함수 추가 ⬇️ ---
-    /// A11y 알림을 메인 스레드에서 약간의 지연 후 실행합니다.
-    /// (즉시 실행하면 VoiceOver가 액션 이름을 읽는 도중 끊길 수 있음)
-    private func announce(_ message: LocalizedStringKey) {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            UIAccessibility.post(notification: .announcement, argument: message)
-        }
     }
 }
 
@@ -75,9 +41,6 @@ struct HomeEditListRowView: View {
     HomeEditListRowView(
         nodeName: "생명공학연구소",
         nodeNo: "299002",
-        routes: ["207", "306"],
-        onDelete: {},
-        onMoveUp: {},
-        onMoveDown: {}
+        routes: ["207", "306"]
     )
 }

--- a/OffStageApp/Sources/Presentation/TestView.swift
+++ b/OffStageApp/Sources/Presentation/TestView.swift
@@ -13,16 +13,14 @@ struct TestView: View {
             ScrollView {
                 VStack(spacing: 24) {
                     Section(
-                        header: Text(L10n.Test.A11y.headerDeviceInfo)
-                            .accessibilityAddTraits(.isHeader)
+                        header: Text("기기 정보")
                     ) {
                         actionSection
                         responseSection
                     }
 
                     Section(
-                        header: Text(L10n.Test.A11y.headerBusInfo)
-                            .accessibilityAddTraits(.isHeader)
+                        header: Text("버스 정보")
                     ) {
                         locationSection
                     }
@@ -266,10 +264,6 @@ struct TestView: View {
             Spacer()
             Text(value) // 시각적 UI
         }
-        // --- ⬇️ A11y 3단계 전략 적용 ⬇️ ---
-        .accessibilityElement(children: .ignore) // 1. [Element] 개별 Text 무시
-        .accessibilityLabel(title) // 2. [Label] "제목"
-        .accessibilityValue(Text(value)) // 3. [Value] "값"
     }
 
     @ViewBuilder
@@ -279,10 +273,6 @@ struct TestView: View {
             Spacer()
             Text(value)
         }
-        // --- ⬇️ A11y 3단계 전략 적용 ⬇️ ---
-        .accessibilityElement(children: .ignore) // 1. [Element]
-        .accessibilityLabel(title) // 2. [Label]
-        .accessibilityValue(Text(value)) // 3. [Value]
     }
 
     private func formattedCoordinate(_ value: Double) -> String {


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #108 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- 앱의 프로토타입 단계에 불필요한 접근성(A11y) 관련 코드를 Presentation 레이어 전반에 걸쳐 제거하여 코드베이스를 간소화했습니다.

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- 다수의 View 파일에서 `.accessibility` 수정자 및 관련 로직을 제거했습니다.
- `L10n` 파일의 A11y 관련 문자열 리소스를 삭제했습니다.

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->