### PR TITLE
✨ Feature: #115 [VO] 권한 설정 아이콘 VoiceOver 레이블 추가

### DIFF
--- a/OffStageApp/Sources/Presentation/Home/SubView/PermissionSubView.swift
+++ b/OffStageApp/Sources/Presentation/Home/SubView/PermissionSubView.swift
@@ -32,6 +32,7 @@ struct PermissionSubView: View {
                             .resizable()
                             .scaledToFit()
                             .frame(width: 60, height: 60)
+                            .accessibilityLabel(deniedPermissions.contains(.location) ? "거절됨" : "승인됨")
 
                         VStack(alignment: .leading, spacing: 4) {
                             Text("위치 정보 접근")
@@ -51,6 +52,7 @@ struct PermissionSubView: View {
                             .resizable()
                             .scaledToFit()
                             .frame(width: 60, height: 60)
+                            .accessibilityLabel(deniedPermissions.contains(.camera) ? "거절됨" : "승인됨")
 
                         VStack(alignment: .leading, spacing: 4) {
                             Text("카메라 접근")
@@ -70,6 +72,7 @@ struct PermissionSubView: View {
                             .resizable()
                             .scaledToFit()
                             .frame(width: 60, height: 60)
+                            .accessibilityLabel(deniedPermissions.contains(.microphone) ? "거절됨" : "승인됨")
 
                         VStack(alignment: .leading, spacing: 4) {
                             Text("마이크 접근")


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #115

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

**Why:**
- 권한 설정 화면의 아이콘이 VoiceOver에서 단순 "이미지"로만 읽혀, 사용자가 각 권한의 승인/거절 상태를 파악하기 어려웠습니다.
- 시각적 아이콘이 전달하는 상태 정보를 VoiceOver 사용자도 명확하게 인지할 수 있도록 개선합니다.

**How:**
- `PermissionSubView.swift`의 위치, 카메라, 마이크 권한 아이콘 `Image`에 `.accessibilityLabel`을 추가했습니다.
- 권한 상태(`deniedPermissions`)에 따라 "승인됨" 또는 "거절됨"으로 VoiceOver 레이블을 동적으로 설정하여, 현재 상태를 정확하게 전달하도록 구현했습니다.

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->

https://github.com/user-attachments/assets/bffd02b5-4cfe-4b44-958e-e1046372713e

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] VoiceOver가 활성화된 상태에서 권한 설정 Sheet 진입
- [x] 각 권한(위치, 카메라, 마이크) 상태가 "승인됨" 또는 "거절됨"으로 올바르게 읽히는지 확인
- [x] 설정 앱에서 권한을 변경한 뒤 다시 Sheet에 진입했을 때, 변경된 상태가 정확히 반영되어 읽히는지 확인

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- Accessibility(#A11y) 개선 작업입니다.

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->

- `PermissionSubView.swift`의 동적 라벨링 로직을 중점적으로 확인 부탁드립니다.
- 현재 "승인됨", "거절됨" 문자열이 하드코딩되어 있는데, L10n(현지화) 처리가 필요할지 의견 주시면 감사하겠습니다.