### PR TITLE
✨ Feature: #117 [VO] 정류장 상세 화면 VoiceOver 접근성 개선

### DIFF
--- a/OffStageApp/Sources/Presentation/BusStation/BusStationView.swift
+++ b/OffStageApp/Sources/Presentation/BusStation/BusStationView.swift
@@ -74,6 +74,8 @@ struct BusStationView: View {
                 Button(action: { router.popToRoot() }) {
                     Image(systemName: "house")
                 }
+                .accessibilityLabel("홈 화면으로 가기")
+                .accessibilityHint("홈으로 가려면 두번 탭하십시오.")
             )
 
             RefreshButton(countdown: countdown, rotationAngle: $rotationAngle) {
@@ -109,8 +111,9 @@ struct BusStationView: View {
             ActivityIndicator(isAnimating: .constant(true), style: .large)
                 .frame(maxWidth: .infinity, alignment: .center)
                 .padding(.vertical, 40)
+                .accessibilityHidden(true)
 
-        case let .success(routes):
+        case let .refreshing(routes), let .success(routes):
             if routes.isEmpty {
                 Group {
                     if viewModel.input.routes.isEmpty {

--- a/OffStageApp/Sources/Presentation/BusStation/BusStationViewModel.swift
+++ b/OffStageApp/Sources/Presentation/BusStation/BusStationViewModel.swift
@@ -1,11 +1,13 @@
 import BusAPI
 import Foundation
+import UIKit
 
 @MainActor
 final class BusStationViewModel: ObservableObject {
     enum ViewState {
         case idle
         case loading
+        case refreshing([RouteDetail])
         case success([RouteDetail])
         case error(Error)
     }
@@ -73,7 +75,12 @@ final class BusStationViewModel: ObservableObject {
     }
 
     func refresh() {
-        viewState = .loading
+        switch viewState {
+        case let .success(details):
+            viewState = .refreshing(details)
+        default:
+            viewState = .loading
+        }
         Task { await fetchArrivals() }
     }
 
@@ -138,9 +145,8 @@ final class BusStationViewModel: ObservableObject {
                 }
             }
 
-            print("DETAIL \n\n\n\n\n\(details)\n\n\n\n\n\n")
-
             viewState = .success(details)
+            UIAccessibility.post(notification: .announcement, argument: "버스 도착정보가 갱신되었습니다.")
         } catch {
             viewState = .error(error)
         }

--- a/OffStageApp/Sources/Presentation/BusStation/SubView/BusStationRowSubView.swift
+++ b/OffStageApp/Sources/Presentation/BusStation/SubView/BusStationRowSubView.swift
@@ -20,6 +20,36 @@ struct BusStationRowSubView: View {
         isFavorite
     }
 
+    private var routeInfoAccessibilityLabel: String {
+        var label = "\(route.routeNumber)번 버스"
+        label += route.direction.isEmpty ? ", 방면 정보 없음" : ",\(route.direction) 방면"
+        if route.arrivals.isEmpty {
+            label += ", 도착 정보 없음"
+        } else {
+            for (index, arrival) in
+                route.arrivals.enumerated()
+            {
+                var arrivalLabel = ""
+                if route.arrivals.count > 1 {
+                    arrivalLabel += (
+                        index == 0) ? ", 첫번째 버스" : ", 두번째 버스"
+                } else {
+                    arrivalLabel += ","
+                }
+
+                arrivalLabel += "\(arrival.arrivalDescription)"
+
+                if let remaining =
+                    arrival.remainingStopsDescription
+                {
+                    arrivalLabel += ", \(remaining)"
+                }
+                label += arrivalLabel
+            }
+        }
+        return label
+    }
+
     var body: some View {
         HStack(alignment: .top) {
             VStack(alignment: .leading, spacing: 8) {
@@ -57,6 +87,8 @@ struct BusStationRowSubView: View {
                     }
                 }
             }
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(routeInfoAccessibilityLabel)
 
             CircularToggleButton(isOn: isSavedOn) {
                 if isSavedOn {

--- a/OffStageApp/Sources/Presentation/BusStation/SubView/CircularToggleButton.swift
+++ b/OffStageApp/Sources/Presentation/BusStation/SubView/CircularToggleButton.swift
@@ -28,5 +28,9 @@ struct CircularToggleButton: View {
                     .font(.system(size: 24, weight: .regular))
             }
         }
+        .accessibilityLabel("즐겨찾기 버튼")
+        .accessibilityValue(isOn ? "선택됨" : "선택 안됨")
+        .accessibilityHint("즐겨찾기 하려면 두번 탭하십시오.")
+        .accessibilityAddTraits(.isButton)
     }
 }


### PR DESCRIPTION
## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
- Closes #117

---

### 🧶 주요 변경 내용 (Summary)
정류장 상세 화면의 VoiceOver 접근성을 대폭 개선했습니다.

1.  **버스 리스트 항목 그룹화 (`BusStationRowSubView.swift`)**
    * 기존에 분리되어 읽히던 버스 노선, 방면, 도착 정보 텍스트들을 `.accessibilityElement(children: .ignore)`로 그룹화했습니다.
    * `routeInfoAccessibilityLabel` computed property를 추가하여, "00번 버스, 00방면, 첫번째 버스 0분 0초 전, 두번째 버스 0분 0초 전" 과 같이 모든 노선 정보를 한 번에 읽도록 변경했습니다.
    * 이를 통해 노선 정보와 즐겨찾기 버튼이 명확히 분리되었습니다.

2.  **즐겨찾기 버튼 (`CircularToggleButton.swift`)**
    * `accessibilityLabel("즐겨찾기 버튼")`을 추가했습니다.
    * `.accessibilityValue(isOn ? "선택됨" : "선택 안됨")`을 추가하여 현재 상태를 명확히 알 수 있도록 했습니다.
    * `.accessibilityHint` 및 `.accessibilityAddTraits(.isButton)`을 추가했습니다.

3.  **새로고침 시 VoiceOver 경험 개선 (`BusStationViewModel.swift`, `BusStationView.swift`)**
    * `ViewState`에 `.refreshing([RouteDetail])` 상태를 추가하여, 새로고침 시에도 기존 리스트 데이터를 유지하도록 했습니다. (로딩 인디케이터만 노출되던 문제 수정)
    * 로딩 인디케이터(`ActivityIndicator`)는 `.accessibilityHidden(true)`로 숨김 처리했습니다.
    * 데이터 갱신 완료 시 `UIAccessibility.post(notification: .announcement, ...)`를 호출하여 "버스 도착정보가 갱신되었습니다."라고 음성 안내를 하도록 구현했습니다.

4.  **기타 개선 (`BusStationView.swift`)**
    * '홈 버튼'(`Image(systemName: "house")`)에 라벨과 힌트를 추가했습니다.

---

### 📸 스크린샷 (Optional)

https://github.com/user-attachments/assets/6f4b318c-552d-4d3e-bb26-64c6011142cb


---

### 🧪 테스트 / 검증 내역
- [x] VoiceOver를 켠 상태로 정류장 상세 진입
- [x] 버스 리스트 항목 스와이프 시, 노선 정보가 하나의 단위로 묶여 읽히는지 확인
- [x] 즐겨찾기 버튼이 "즐겨찾기 버튼, 선택됨/선택 안됨"으로 분리되어 읽히는지 확인
- [x] 새로고침(당겨서 새로고침 또는 버튼) 시, "버스 도착정보가 갱신되었습니다." 음성 안내가 나오는지 확인
- [x] 새로고침 중에도 리스트가 사라지지 않아 VoiceOver 포커스가 유지되는지 확인
- [x] '홈 버튼' 라벨링 확인

---

### 💬 기타 공유 사항
- `BusStationViewModel`의 `refreshing` 상태 추가가 핵심입니다. 이를 통해 VoiceOver 포커스가 로딩 중 사라지거나 엉뚱한 곳으로 튀는 현상을 방지했습니다.

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
- `BusStationRowSubView.swift`: `routeInfoAccessibilityLabel`의 정보 조합 로직
- `BusStationViewModel.swift`: `refresh` 함수의 `refreshing` 상태 분기 처리 로직