### PR TITLE
✨ Feature: #118 [VO] 카메라 버스 인식 화면 접근성 개선

### DIFF
--- a/OffStageApp/Sources/Presentation/BusVision/BusVisionView.swift
+++ b/OffStageApp/Sources/Presentation/BusVision/BusVisionView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 /// router와 연결되는 메인 버스 비전 뷰
 struct BusVisionView: View {
@@ -33,6 +34,7 @@ struct BusVisionView: View {
                         .font(.system(size: 120, weight: .black, design: .rounded))
                         .foregroundStyle(Color.white)
                         .frame(maxWidth: .infinity, alignment: .center)
+                        .accessibilityHidden(UIAccessibility.isVoiceOverRunning)
                 }
             }
             .padding(.vertical)


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #118

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

카메라 버스 인식 화면(`BusVisionView.swift`)의 VoiceOver 접근성을 개선했습니다.

**1. 인식 중 로딩 UI 개선 (Commit `cd7dd61`)**
* **Why:** 카메라로 버스 번호를 인식하는 동안 표시되는 `ProgressView`가 VoiceOver 사용자에게 아무런 정보를 제공하지 않아, 앱의 현재 상태를 알기 어려웠습니다.
* **How:** `ProgressView`에 `.accessibilityLabel("버스 번호 인식 중")`과 `.accessibilityHint("버스가 인식되면 번호가 표시됩니다.")`를 추가하여, 현재 상태와 다음 동작에 대한 정보를 제공하도록 했습니다.

**2. TTS와 VoiceOver 중복 출력 수정 (Commit `1a1b0a4`)**
* **Why:** 버스 번호 인식 시, 앱의 자체 TTS가 버스 번호를 읽어주는 동시에 VoiceOver도 UI의 `Text`를 읽으려고 시도하여 소리가 중복되는 문제가 있었습니다.
* **How:** VoiceOver가 활성화된 상태(`UIAccessibility.isVoiceOverRunning`)인지 확인하여, VoiceOver 실행 중일 경우 버스 번호를 표시하는 `Text` 뷰에 `.accessibilityHidden(true)`를 적용했습니다. 이를 통해 VoiceOver는 텍스트에 접근하지 않고 앱의 자체 TTS만 동작하도록 보장합니다.

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->

https://github.com/user-attachments/assets/c501d787-05ff-43c4-9a45-bf8e4e2ce8fd


---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] VoiceOver가 활성화된 상태로 카메라 인식 화면 진입
- [x] 버스 인식 전 (로딩 중), `ProgressView`에서 "버스 번호 인식 중, 버스가 인식되면 번호가 표시됩니다."라고 정상적으로 읽히는지 확인
- [x] 버스 번호 인식 성공 시, VoiceOver가 인식된 텍스트를 읽지 않고(중복 출력 없이) 앱의 자체 TTS만 버스 번호를 읽어주는지 확인

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- VoiceOver 사용자(#A11y)가 카메라 인식 기능 사용 시 겪는 두 가지 주요 불편 사항(상태 불명확, 소리 중복)을 해결했습니다.

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->

- `BusVisionView.swift`의 `UIAccessibility.isVoiceOverRunning`을 사용한 조건부 `.accessibilityHidden(true)` 적용 로직을 확인 부탁드립니다.