### PR TITLE
✨ Feature: #141 STT 기반 버스 번호 음성 인식 구현

### DIFF
--- a/OffStageApp/Sources/Presentation/Home/SubView/SheetView.swift
+++ b/OffStageApp/Sources/Presentation/Home/SubView/SheetView.swift
@@ -131,7 +131,9 @@ struct SheetView: View {
 
             VStack(spacing: 20) {
                 Button(action: {
-                    if let matchingRoute = busRoutes.first(where: { $0.routeNumber == recognizedBusNumber }) {
+                    if let matchingRoute = busRoutes
+                        .first(where: { $0.routeNumber.removeParenthesesContent() == recognizedBusNumber })
+                    {
                         onRouteSelected(matchingRoute)
                         print("Confirmed and returned matching route: \(matchingRoute.routeNumber)")
                     } else {

--- a/OffStageApp/Sources/Presentation/Home/SubView/SheetViewModel.swift
+++ b/OffStageApp/Sources/Presentation/Home/SubView/SheetViewModel.swift
@@ -16,6 +16,7 @@ class SheetViewModel: ObservableObject {
     @Published var currentBusStop: BusStop? = nil
 
     private let synthesizer = AVSpeechSynthesizer()
+    private let sttManager = STTManager()
 
     init() {}
 
@@ -48,23 +49,41 @@ class SheetViewModel: ObservableObject {
     }
 
     private func speakAndListenMock(text: String) async -> String? {
+        let audioSession = AVAudioSession.sharedInstance()
+        try? audioSession.setCategory(.playAndRecord, mode: .default, options: [.defaultToSpeaker, .allowBluetooth])
+        try? audioSession.setActive(true)
+
         let utterance = AVSpeechUtterance(string: text)
         utterance.voice = AVSpeechSynthesisVoice(language: "ko-KR")
         utterance.rate = 0.5
         synthesizer.speak(utterance)
 
-        try? await Task.sleep(nanoseconds: 3_000_000_000)
-
-        if synthesizer.isSpeaking {
-            synthesizer.stopSpeaking(at: .immediate)
+        // TTS가 끝날 때까지 대기
+        while synthesizer.isSpeaking {
+            try? await Task.sleep(nanoseconds: 100_000_000) // 0.1초씩 체크
         }
 
-        return "92-1"
+        // TTS 종료 후 안정화를 위한 짧은 딜레이 0.2초
+        try? await Task.sleep(nanoseconds: 200_000_000)
+
+        // STT 시작
+        sttManager.startListening()
+
+        // 음성 인식 시간 (5초 동안 듣기)
+        try? await Task.sleep(nanoseconds: 5_000_000_000)
+
+        // STT 중지
+        sttManager.stopListening()
+
+        let recognizedText = sttManager.transcript
+        return recognizedText.isEmpty ? nil : recognizedText
     }
 
     func stopSpeaking() {
         if synthesizer.isSpeaking {
             synthesizer.stopSpeaking(at: .immediate)
         }
+        // ✅ 추가: STT도 함께 중지
+        sttManager.stopListening()
     }
 }


### PR DESCRIPTION
## ✨ What's this PR?
### 📌 관련 이슈 (Related Issue)
- Closes #141

---

### 🧶 주요 변경 내용 (Summary)

#### 1. STTManager 통합
- `SheetViewModel`에 `STTManager` 인스턴스 추가
- Mock 데이터("92-1") 대신 실제 음성 인식으로 버스 번호 입력

#### 2. 음성 인식 흐름 구현
- **TTS (Text-to-Speech)**: "번호를 말씀해주세요." 안내 음성 출력
- **AVAudioSession 설정**: `.playAndRecord` 카테고리로 TTS와 STT 동시 지원
  - `.defaultToSpeaker`: 이어폰 미연결 시 스피커 출력
  - `.allowBluetooth`: 블루투스 이어폰 지원
- **STT (Speech-to-Text)**: TTS 완료 후 5초 동안 음성 인식
- **결과 반환**: 인식된 텍스트를 `recognizedBusNumber`에 저장

#### 3. 버스 노선 매칭 개선
- `SheetView`의 매칭 로직에 `removeParenthesesContent()` 적용
- 괄호 포함된 노선 번호도 정확하게 매칭 (예: "92-1(급행)" → "92-1")

#### 4. 리소스 정리
- `stopSpeaking()` 메서드에서 TTS와 STT 모두 중지하도록 개선

---

### 📸 스크린샷 (Optional)

https://github.com/user-attachments/assets/4acb066c-d813-49f8-88df-18d0ae146976

---

### 🧪 테스트 / 검증 내역

- [x] 실제 디바이스에서 음성 인식 정상 동작 확인
- [x] TTS 음성이 스피커로 정상 출력 확인
- [x] STT로 인식된 버스 번호가 확인 화면에 표시되는지 확인
- [x] 버스 노선 매칭 후 BusArrivalView로 네비게이션 정상 동작 확인
- [x] 이어폰 연결 시 이어폰으로 출력되는지 확인

---

### 💬 기타 공유 사항

- **iOS 시뮬레이터 제한**: STT는 실제 디바이스에서만 정상 동작하므로 실기기 테스트 필수
- **네트워크 필요**: Apple의 음성 인식 서버와 통신하므로 네트워크 연결 필요
- **음성 인식 시간**: 현재 5초로 설정되어 있으며, 추후 음성 인식 완료를 인식해서 넘어가는 로직으로 수정 고려.
- **한국어 인식**: `ko-KR` 로케일로 설정되어 한국어 버스 번호 인식 최적화

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)

- `SheetViewModel.swift`의 `speakAndListenMock()` 메서드
  - TTS → STT 전환 흐름
  - AVAudioSession 설정 방식
- `SheetView.swift`의 134-136번 줄
  - `removeParenthesesContent()` 매칭 로직