### PR TITLE
🐛 Fix: #152 '네, 맞아요' 버튼 탭 시 네비게이션 누락 버그 수정

### DIFF
--- a/OffStageApp/Sources/Presentation/Home/SubView/SheetView.swift
+++ b/OffStageApp/Sources/Presentation/Home/SubView/SheetView.swift
@@ -154,10 +154,10 @@ struct SheetView: View {
                         onRouteSelected(matchingRoute)
                         print("Confirmed and returned matching route: \(matchingRoute.routeNumber)")
                     } else {
+                        // TODO: 일치하는 버스 노선이 없을 때 처리 필요
                         print("No matching bus route found for recognized number: \(recognizedBusNumber)")
-                        // Optionally, you could keep the sheet open or show an alert here.
+                        dismiss()
                     }
-                    dismiss()
                 }) {
                     Text("네, 맞아요.")
                         .font(.title2)


### PR DESCRIPTION
## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
- Closes #152

---

### 🧶 주요 변경 내용 (Summary)
- 'N번 버스가 맞나요?' 시트에서 '네, 맞아요' 버튼을 탭했을 때, `onRouteSelected`가 호출되어도 `dismiss()`가 무조건 실행되어 다음 화면으로의 네비게이션이 누락되던 버그를 수정했습니다.
- `SheetView.swift`의 '네, 맞아요' 버튼 액션 내 `dismiss()` 호출 위치를 변경했습니다.
  - 일치하는 노선이 있는 경우 (`if let`): `dismiss()`를 제거하여 `onRouteSelected`가 네비게이션을 정상적으로 처리하도록 수정
  - 일치하는 노선이 없는 경우 (`else`): `dismiss()`를 호출하여 시트가 닫히도록 로직 유지

---

### 📸 스크린샷 (Optional)
*(UI 변경 사항 없음)*

---

### 🧪 테스트 / 검증 내역
- [x] '네, 맞아요' 버튼 탭 시 다음 화면으로 정상 전환되는 것 확인
- [x] (테스트용) 일치하는 노선이 없는 번호를 인식시켰을 때, '네, 맞아요'를 눌러도 시트만 닫히고 화면 전환이 일어나지 않음 (else문 dismiss() 동작 확인)

---

### 💬 기타 공유 사항
- `else` 블록에 `// TODO: 일치하는 버스 노선이 없을 때 처리 필요` 주석을 추가했습니다. 현재는 시트가 닫히지만, 추후 "일치하는 노선이 없습니다" 알림 등이 필요할 수 있습니다.

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
- `SheetView.swift`의 '네, 맞아요' 버튼 `action` 클로저를 확인해주세요.
- `dismiss()` 호출이 `else` 블록으로 올바르게 이동했는지 확인 부탁드립니다.