### PR TITLE
🐛 Fix: #154 '버스 인식하기' 버튼 활성화 조건 개선 (2정거장/2분 전)

### DIFF
--- a/OffStageApp/Sources/Domain/Model/BusUrgencyStatus.swift
+++ b/OffStageApp/Sources/Domain/Model/BusUrgencyStatus.swift
@@ -1,25 +1,30 @@
 import Foundation
 
+/// 버스 도착 긴급도 상태
+///
+/// **관리 항목:**
+/// - API 갱신 주기 (refreshIntervalSeconds)
+/// - `버스 인식하기` 버튼 활성화 상태
+///
+/// **향후 고려사항:**
+/// - 남은 시간 60초 미만: "곧 도착" 문구 표시
+/// - 남은 정류장 1개 이하: "전 정류장에서 출발했습니다." 문구 표시
+/// - 현재는 `OffStageApp/Sources/Presentation/Home/SubView/BusArrivalView.swift`에서 관리 중
 public enum BusUrgencyStatus: String {
     case fiveOrMoreStops = "5개 정류장 이상"
     case threeOrFourStops = "3-4개 정류장 전"
-    case twoStops = "2개 정류장 전"
-    case oneStop = "1개 정류장 전"
     case arrived = "곧도착"
     case notApplicable = "해당 없음" // 조건에 맞지 않을 때
 
+    /// API 갱신 주기 (초 단위)
     public var refreshIntervalSeconds: UInt64 {
         switch self {
         case .fiveOrMoreStops:
-            90
-        case .threeOrFourStops:
             60
-        case .twoStops:
+        case .threeOrFourStops:
             30
-        case .oneStop:
-            15
         case .arrived:
-            10
+            15
         case .notApplicable:
             15 // Default for no arrival info
         }
@@ -36,14 +41,10 @@ public enum BusUrgencyStatus: String {
             status = .fiveOrMoreStops
         } else if remainingStops >= 3 {
             status = .threeOrFourStops
-        } else if remainingStops == 2 {
-            status = .twoStops
-        } else if remainingStops == 1 {
-            status = .oneStop
-        } else if remainingStops == 0 {
+        } else if remainingStops <= 2 {
             status = .arrived
         }
-        if let estimatedTime = estimatedTimeInSeconds, estimatedTime < 60 {
+        if let estimatedTime = estimatedTimeInSeconds, estimatedTime < 120 {
             status = .arrived
         }
         return status

--- a/OffStageApp/Sources/Presentation/Home/SubView/BusArrivalView.swift
+++ b/OffStageApp/Sources/Presentation/Home/SubView/BusArrivalView.swift
@@ -129,16 +129,15 @@ struct BusArrivalInfoView: View {
     }
 
     private func formatArrivalTime(_ seconds: Int?) -> String {
-        if busUrgencyStatus == .arrived {
-            return "잠시 후"
-        }
         guard let seconds else { return "정보 없음" }
         let minutes = seconds / 60
         let remainingSeconds = seconds % 60
         if minutes >= 1 {
             return "\(minutes)분 \(remainingSeconds)초 후"
         }
-        return "\(remainingSeconds)초 후"
+
+        return "잠시 후"
+        // return "\(remainingSeconds)초 후"
     }
 }
 

--- a/OffStageApp/Sources/Presentation/Home/SubView/BusArrivalViewModel.swift
+++ b/OffStageApp/Sources/Presentation/Home/SubView/BusArrivalViewModel.swift
@@ -143,7 +143,7 @@ final class BusArrivalViewModel: ObservableObject {
     }
 
     private func updateBusVisionButtonState() {
-        if busUrgencyStatus == .oneStop || busUrgencyStatus == .arrived {
+        if busUrgencyStatus == .arrived {
             isBusVisionButtonEnabled = true
         } else {
             isBusVisionButtonEnabled = false


### PR DESCRIPTION
## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
- Closes #154

---

### 🧶 주요 변경 내용 (Summary)
- '버스 인식하기' 버튼의 활성화 조건(1정거장/1분 전)이 너무 빡빡하다는 이슈(#154)를 해결하기 위해, 활성화 시점을 (2개 정류장 이하) 또는 (도착 2분 전)으로 완화했습니다.

- **`BusUrgencyStatus.swift`**
  - `.arrived` 상태의 정의를 '2개 정류장 이하' 또는 '120초 미만'으로 변경했습니다.
  - 불필요해진 `.oneStop`, `.twoStops` case를 `.arrived`로 통합했습니다.
  - 상태 통합에 따라 API 갱신 주기(`refreshIntervalSeconds`)를 조정했습니다. (`.arrived` -> 15초)

- **`BusArrivalViewModel.swift`**
  - `updateBusVisionButtonState` 로직을 `.arrived` 상태일 때만 활성화되도록 단순화했습니다. (기존: `.oneStop || .arrived`)

- **`BusArrivalView.swift`**
  - `formatArrivalTime` 로직을 수정하여, 1분 미만 도착 시 'M초 후' 대신 '잠시 후' 텍스트가 표시되도록 변경했습니다.

---

### 📸 스크린샷 (Optional)
*(UI 로직 변경으로, 시각적 변경 사항은 없음)*

---

### 🧪 테스트 / 검증 내역
- [x] 버스가 2정거장 남았을 때 '버스 인식하기' 버튼이 활성화되는지 확인
- [x] 버스 도착 예정 시간이 120초 미만일 때 '버스 인식하기' 버튼이 활성화되는지 확인
- [x] 버스 도착 예정 시간이 1분 미만일 때 (예: 45초) 도착 시간이 "잠시 후"로 표시되는지 확인
- [x] 버스가 3정거장 이상 남았을 때 버튼이 비활성화 상태인지 확인

---

### 💬 기타 공유 사항
- `BusUrgencyStatus.swift`의 case를 단순화하면서 API 갱신 주기도 함께 조정했습니다.
- `BusArrivalView`에서 "잠시 후"로 문구를 변경한 것은, 1분 미만일 때 "59초 후", "58초 후"... 로 표시되는 것이 오히려 너무 번잡하게 느껴질 수 있어 수정한 사항입니다.

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
- `BusUrgencyStatus.swift`의 `init(remainingStops:estimatedTimeInSeconds:)` 로직을 중점적으로 확인해주세요.
- `BusArrivalViewModel.swift`의 `updateBusVisionButtonState` 로직이 새로운 `BusUrgencyStatus` 정책과 맞는지 확인 부탁드립니다.