### PR TITLE
♻️ Refactor: #161 하드코딩된 문자열을 L10n으로 마이그레이션

### DIFF
--- a/OffStageApp/Resources/Localizable.xcstrings
+++ b/OffStageApp/Resources/Localizable.xcstrings
@@ -1,52 +1,450 @@
 {
   "sourceLanguage" : "ko",
   "strings" : {
-    " 입니다." : {
-
-    },
-    "**%@** 정류장을 통과하는 버스 번호를 입력하세요." : {
-
-    },
-    "%@ 인근" : {
-
-    },
-    "%@번 탐지중" : {
-
-    },
-    "API Calls" : {
-
-    },
-    "API Response" : {
-
-    },
-    "common.a11y.action.delete" : {
-      "comment" : "A11y: 공용: 삭제 액션 이름 (2단계에서 추가했다면 생략)",
-      "extractionState" : "stale",
+    "bus.arrival.currentBusLocation" : {
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Current bus location:"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "삭제"
+            "value" : "현재 운행중인 버스 위치:"
           }
         }
       }
     },
-    "common.a11y.button.home" : {
-      "comment" : "A11y: 홈으로 이동 버튼",
-      "extractionState" : "stale",
+    "bus.arrival.error.loadFailed" : {
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Failed to load arrival info: %@"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "홈으로 이동"
+            "value" : "도착 정보를 불러오는 데 실패했습니다: %@"
+          }
+        }
+      }
+    },
+    "bus.arrival.imminent" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Arriving soon"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "도착 예정"
+          }
+        }
+      }
+    },
+    "bus.arrival.noInformation" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No arrival information"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "도착 예정 정보 없음"
+          }
+        }
+      }
+    },
+    "bus.arrival.noOperatingRoutes" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "There are no routes currently in operation."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "현재는 운행중인 노선이 없습니다."
+          }
+        }
+      }
+    },
+    "busArrival.a11y.format.arrived" : {
+      "comment" : "버스 도착: 도착 완료 텍스트",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "arrived"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "도착"
+          }
+        }
+      }
+    },
+    "busArrival.a11y.format.arriving" : {
+      "comment" : "버스 도착: 도착 예정 텍스트",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "arriving"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "도착 예정"
+          }
+        }
+      }
+    },
+    "busArrival.a11y.format.minutesSeconds" : {
+      "comment" : "버스 도착 A11y: 분/초 후",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "In %@ min %@ sec"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@분 %@초 후"
+          }
+        }
+      }
+    },
+    "busArrival.a11y.format.noInfo" : {
+      "comment" : "버스 도착 A11y: 정보 없음",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No information"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "정보 없음"
+          }
+        }
+      }
+    },
+    "busArrival.a11y.format.previousStop" : {
+      "comment" : "버스 도착: 전 정류장",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "departed from the previous stop."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "전 정류장에서 출발했습니다."
+          }
+        }
+      }
+    },
+    "busArrival.a11y.format.routeNumber" : {
+      "comment" : "버스 도착: 노선 번호 포맷",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bus %@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@번"
+          }
+        }
+      }
+    },
+    "busArrival.a11y.format.seconds" : {
+      "comment" : "버스 도착 A11y: 초 후",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "In %@ sec"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@초 후"
+          }
+        }
+      }
+    },
+    "busArrival.a11y.format.soon" : {
+      "comment" : "버스 도착 A11y: 잠시 후",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Soon"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "잠시 후"
+          }
+        }
+      }
+    },
+    "busArrival.a11y.format.stopsAway" : {
+      "comment" : "버스 도착: N번째 전 정류장",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "departed from %@ stops before."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@번째전 정류장에서 출발했습니다."
+          }
+        }
+      }
+    },
+    "busVision.debug.detectingWithNumber" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Detecting Bus %@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@번 탐지중"
+          }
+        }
+      }
+    },
+    "busVision.detection.confirmBusNumber" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Is this correct?"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "번이 맞나요?"
+          }
+        }
+      }
+    },
+    "busVision.detection.confirmBusNumberPrefix" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Is the bus number\nyou want to board\n"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "타려는 버스 번호가\n"
+          }
+        }
+      }
+    },
+    "busVision.detection.detectingBusNumber" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Detecting Bus %@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@번 탐지중"
+          }
+        }
+      }
+    },
+    "busVision.detection.inProgress" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recognizing bus"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "버스 인식 중"
+          }
+        }
+      }
+    },
+    "busVision.detection.retry" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No, I'll recognize again"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "아니요, 다시 인식할게요"
+          }
+        }
+      }
+    },
+    "busVision.detection.selectFromList" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No, I'll select from list"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "아니요, 목록에서 고를게요"
+          }
+        }
+      }
+    },
+    "busVision.detection.wrongBusNumber" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This is a different bus number."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "다른 번호의 버스입니다."
+          }
+        }
+      }
+    },
+    "common.confirmation.no" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "아니오"
+          }
+        }
+      }
+    },
+    "common.confirmation.yes" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yes, that's right."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "네, 맞아요."
+          }
+        }
+      }
+    },
+    "common.confirmation.yesShort" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yes"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "예"
           }
         }
       }
     },
     "common.ui.button.cancel" : {
       "comment" : "공용: 취소 버튼",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancel"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -57,8 +455,14 @@
     },
     "common.ui.button.next" : {
       "comment" : "공용: 다음 버튼",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Next"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -69,8 +473,14 @@
     },
     "common.ui.button.previous" : {
       "comment" : "공용: 이전 버튼",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Previous"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -81,8 +491,14 @@
     },
     "common.ui.button.retry" : {
       "comment" : "공용: 재시도 버튼",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Retry"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -93,8 +509,14 @@
     },
     "common.ui.button.save" : {
       "comment" : "공용: 저장 버튼",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Save"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -103,10 +525,84 @@
         }
       }
     },
+    "common.ui.suffix.is" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : " 입니다."
+          }
+        }
+      }
+    },
+    "common.ui.unknownLocation" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unknown location"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "알 수 없는 위치"
+          }
+        }
+      }
+    },
+    "debug.mvp.placeholder.routeExample" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "e.g., 441"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "예: 441"
+          }
+        }
+      }
+    },
+    "debug.mvp.prompt.enterRouteForStop" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enter the bus number passing through **%@** stop."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**%@** 정류장을 통과하는 버스 번호를 입력하세요."
+          }
+        }
+      }
+    },
     "debug.ui.button.apiTest" : {
       "comment" : "디버그: Api 테스트 뷰 이동 버튼",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Api Test View"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -117,8 +613,14 @@
     },
     "debug.ui.button.clear" : {
       "comment" : "디버그: 로그 지우기 버튼",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clear"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -129,8 +631,14 @@
     },
     "debug.ui.button.sttTtsTest" : {
       "comment" : "디버그: STT/TTS 테스트 뷰 이동 버튼",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "STT & TTS Test View"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -141,8 +649,14 @@
     },
     "debug.ui.link.busVision" : {
       "comment" : "디버그: 버스 비전 테스트 링크",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "207, 306"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -153,8 +667,14 @@
     },
     "debug.ui.title" : {
       "comment" : "디버그: 화면 타이틀",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Debug"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -163,10 +683,447 @@
         }
       }
     },
+    "debug.ui.title.apiFlow" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "API Flow"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "API Flow"
+          }
+        }
+      }
+    },
+    "debug.ui.title.l10nTest" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L10n Test"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "L10n Test"
+          }
+        }
+      }
+    },
+    "debug.ui.toggle.switchToEnglish" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Switch to English"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "영어로 전환"
+          }
+        }
+      }
+    },
+    "home.a11y.announcement.loading" : {
+      "comment" : "홈 화면: 로딩 시작 음성 안내",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Loading nearby stop information."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "주변 정류장 정보를 불러오고 있습니다."
+          }
+        }
+      }
+    },
+    "home.a11y.announcement.loadingNearby" : {
+      "comment" : "홈 화면: 근처 정류장 로딩 음성 안내",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Loading nearby stop information."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "근처 정류장 정보를 불러오고 있습니다."
+          }
+        }
+      }
+    },
+    "home.a11y.button.mic.hint.loading" : {
+      "comment" : "홈 화면: 마이크 버튼 힌트(로딩 중)",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Still searching for nearby stops. Please wait a moment."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "아직 주변 정류장을 찾는 중입니다. 잠시만 기다려주세요."
+          }
+        }
+      }
+    },
+    "home.a11y.button.mic.hint.noStop" : {
+      "comment" : "홈 화면: 마이크 버튼 힌트(정류장 없음)",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No nearby stops found. Please check location permission or try again."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "주변 정류장을 찾지 못했습니다. 위치 권한을 확인하거나 다시 시도해 주세요."
+          }
+        }
+      }
+    },
+    "home.a11y.button.mic.hint.ready" : {
+      "comment" : "홈 화면: 마이크 버튼 힌트(준비됨)",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Double tap to search for the bus you need to take by voice."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "음성으로 타야할 버스를 검색하려면 두 번 탭해주세요."
+          }
+        }
+      }
+    },
+    "home.a11y.button.mic.label" : {
+      "comment" : "홈 화면: 마이크 버튼 접근성 레이블",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Voice input button for bus number"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "타야할 버스 번호 음성 입력 버튼"
+          }
+        }
+      }
+    },
+    "home.button.findBus" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Find Bus"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "버스 찾기"
+          }
+        }
+      }
+    },
+    "home.button.findNearbyStops" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Find Nearby Stops"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "주변 정류장 찾기"
+          }
+        }
+      }
+    },
+    "home.map.near" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Near %@"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ 인근"
+          }
+        }
+      }
+    },
+    "home.map.noStopsFound" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No stops found\nin the vicinity."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "주변 탐색된 정류장이\n없습니다."
+          }
+        }
+      }
+    },
+    "home.map.noStopsFound.simple" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No nearby stops."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "주변에 정류장이 없습니다."
+          }
+        }
+      }
+    },
+    "home.sheet.busDetectionGuide" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "You can start bus detection\nwhen the bus leaves two stops before."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "버스가 두번째 전 정류장에서 출발하면\n버스 인식을 시작할 수 있어요."
+          }
+        }
+      }
+    },
+    "home.sheet.notFound" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Not in list."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "목록에 없어요."
+          }
+        }
+      }
+    },
+    "home.sheet.selectBusRoute" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select a route number."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "노선 번호를 선택하세요."
+          }
+        }
+      }
+    },
+    "home.sheet.startBusDetection" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Detect Bus"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "버스 인식하기"
+          }
+        }
+      }
+    },
+    "home.stt.askBusNumber" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Which bus number\nare you taking?"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "몇 번 버스를\n탑승하시나요?"
+          }
+        }
+      }
+    },
+    "home.stt.askBusNumberSimple" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Which bus number are you taking?"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "몇번 버스를 탑승하시나요?"
+          }
+        }
+      }
+    },
+    "home.stt.confirmNearestStop" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The nearest stop is **%@**. Is this correct?"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "가장 가까운 정류장은 **%@** 입니다. 맞습니까?"
+          }
+        }
+      }
+    },
+    "home.stt.currentNearbyStopPrefix" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nearby stops are\n"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "현재 주변 정류장은\n"
+          }
+        }
+      }
+    },
+    "home.stt.listening" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Listening for the number."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "번호를 듣는중이에요."
+          }
+        }
+      }
+    },
+    "home.stt.promptForBusNumber" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enter the bus number passing through **%@** stop."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "**%@** 정류장을 통과하는 버스 번호를 입력하세요."
+          }
+        }
+      }
+    },
+    "home.stt.searchBasedOnLocation" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Searching for bus information based on current location."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "현재 위치를 기반으로 버스 정보를 검색합니다."
+          }
+        }
+      }
+    },
     "home.ui.empty.button.add" : {
       "comment" : "홈 화면: 즐겨찾기 비어있을 때 추가 버튼",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add My Bus"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -177,8 +1134,14 @@
     },
     "home.ui.empty.subtitle" : {
       "comment" : "홈 화면: 즐겨찾기 비어있을 때 부제목",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Please add your frequently used buses."
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -189,8 +1152,14 @@
     },
     "home.ui.empty.title" : {
       "comment" : "홈 화면: 즐겨찾기 비어있을 때 제목",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No saved history."
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -201,8 +1170,14 @@
     },
     "home.ui.placeholder.search" : {
       "comment" : "홈 화면: 검색창 플레이스홀더",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Search bus routes, stops"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -213,8 +1188,14 @@
     },
     "home.ui.title" : {
       "comment" : "홈 화면: 내비게이션 타이틀",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Home"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -225,8 +1206,14 @@
     },
     "k.appName" : {
       "comment" : "앱의 공식 이름",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "BusONda"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -235,10 +1222,205 @@
         }
       }
     },
+    "permission.a11y.status.denied" : {
+      "comment" : "권한: 거절됨 상태",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Denied"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "거절됨"
+          }
+        }
+      }
+    },
+    "permission.a11y.status.granted" : {
+      "comment" : "권한: 승인됨 상태",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Granted"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "승인됨"
+          }
+        }
+      }
+    },
+    "permission.button.goToSettings" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Go to Settings"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "설정으로 이동"
+          }
+        }
+      }
+    },
+    "permission.camera.reason" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Used for bus number recognition"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "버스 번호 인식을 위해 사용"
+          }
+        }
+      }
+    },
+    "permission.camera.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Camera Access"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "카메라 접근"
+          }
+        }
+      }
+    },
+    "permission.location.reason" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Used for location-based stop guidance"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "사용자 위치 기반 정류장 안내를 위해 사용"
+          }
+        }
+      }
+    },
+    "permission.location.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Location Access"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "위치 정보 접근"
+          }
+        }
+      }
+    },
+    "permission.mic.reason" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Used for voice search feature"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "음성 검색 기능을 위해 사용"
+          }
+        }
+      }
+    },
+    "permission.mic.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Microphone Access"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "마이크 접근"
+          }
+        }
+      }
+    },
+    "permission.prompt.all" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "To use BusONda,\nplease allow access to location, camera, and microphone."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "버스온다를 사용하고 정보를\n위치, 카메라 및 마이크 접근을 허용해 주세요."
+          }
+        }
+      }
+    },
+    "permission.prompt.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "BusONda needs\naccess permissions."
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "버스온다에 접근\n권한이 필요합니다."
+          }
+        }
+      }
+    },
     "quickCamera.ui.title" : {
       "comment" : "빠른 카메라 화면: 타이틀",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Quick Camera"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -249,8 +1431,14 @@
     },
     "sttTtsTest.ui.button.dismissKeyboard" : {
       "comment" : "STT/TTS 테스트: 키보드 내리기 버튼",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dismiss Keyboard"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -261,8 +1449,14 @@
     },
     "sttTtsTest.ui.button.read" : {
       "comment" : "STT/TTS 테스트: TTS 읽기 버튼",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Read"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -273,8 +1467,14 @@
     },
     "sttTtsTest.ui.button.startListening" : {
       "comment" : "STT/TTS 테스트: STT 인식 시작 버튼",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "🎙️ Start Listening"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -285,8 +1485,14 @@
     },
     "sttTtsTest.ui.button.stop" : {
       "comment" : "STT/TTS 테스트: TTS 정지 버튼",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stop"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -297,8 +1503,14 @@
     },
     "sttTtsTest.ui.button.stopListening" : {
       "comment" : "STT/TTS 테스트: STT 인식 중지 버튼",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "🛑 Stop Listening"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -309,8 +1521,14 @@
     },
     "sttTtsTest.ui.placeholder.stt" : {
       "comment" : "STT/TTS 테스트: STT 결과 플레이스홀더",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recognized text will appear here."
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -321,8 +1539,14 @@
     },
     "sttTtsTest.ui.placeholder.tts" : {
       "comment" : "STT/TTS 테스트: TTS 입력 플레이스홀더",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enter text"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -333,8 +1557,14 @@
     },
     "sttTtsTest.ui.title.navigation" : {
       "comment" : "STT/TTS 테스트: 내비게이션 타이틀",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "STT&TTS Test Page"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -345,8 +1575,14 @@
     },
     "sttTtsTest.ui.title.stt" : {
       "comment" : "STT/TTS 테스트: STT 섹션 타이틀",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Speech-to-Text Test"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -357,8 +1593,14 @@
     },
     "sttTtsTest.ui.title.tts" : {
       "comment" : "STT/TTS 테스트: TTS 섹션 타이틀",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Text to Read"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -367,34 +1609,27 @@
         }
       }
     },
-    "test.a11y.header.busInfo" : {
-      "comment" : "A11y: TestView의 '버스 정보' 섹션 헤더",
+    "Switch to English" : {
       "extractionState" : "stale",
       "localizations" : {
-        "ko" : {
+        "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "버스 정보"
-          }
-        }
-      }
-    },
-    "test.a11y.header.deviceInfo" : {
-      "comment" : "A11y: TestView의 '기기 정보' 섹션 헤더",
-      "extractionState" : "stale",
-      "localizations" : {
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "기기 정보"
+            "value" : "Switch to English"
           }
         }
       }
     },
     "test.ui.button.arrivals.subtitle" : {
       "comment" : "테스트: 정류장 도착 정보 버튼 서브타이틀",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "All arrival information based on stop"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -405,8 +1640,14 @@
     },
     "test.ui.button.arrivals.title" : {
       "comment" : "테스트: 정류장 도착 정보 버튼 타이틀",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stop Arrival Info"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -417,8 +1658,14 @@
     },
     "test.ui.button.arrivalsForRoute.subtitle" : {
       "comment" : "테스트: 특정 노선 도착 정보 버튼 서브타이틀",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Search arrivals by stop + route"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -429,8 +1676,14 @@
     },
     "test.ui.button.arrivalsForRoute.title" : {
       "comment" : "테스트: 특정 노선 도착 정보 버튼 타이틀",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Specific Route Arrival"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -441,8 +1694,14 @@
     },
     "test.ui.button.routeBusLocations.subtitle" : {
       "comment" : "테스트: 차량 실시간 위치 버튼 서브타이틀",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Track vehicle locations for selected route"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -453,8 +1712,14 @@
     },
     "test.ui.button.routeBusLocations.title" : {
       "comment" : "테스트: 차량 실시간 위치 버튼 타이틀",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Real-time Vehicle Location"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -465,8 +1730,14 @@
     },
     "test.ui.button.routeInfo.subtitle" : {
       "comment" : "테스트: 노선 기본 정보 버튼 서브타이틀",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Check route details like first/last bus times"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -477,8 +1748,14 @@
     },
     "test.ui.button.routeInfo.title" : {
       "comment" : "테스트: 노선 기본 정보 버튼 타이틀",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Route Basic Info"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -489,8 +1766,14 @@
     },
     "test.ui.button.routeStops.subtitle" : {
       "comment" : "테스트: 노선 경유 정류장 버튼 서브타이틀",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Check stop sequence on route"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -501,8 +1784,14 @@
     },
     "test.ui.button.routeStops.title" : {
       "comment" : "테스트: 노선 경유 정류장 버튼 타이틀",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Route Stops"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -513,8 +1802,14 @@
     },
     "test.ui.button.searchRoute.subtitle" : {
       "comment" : "테스트: 노선 번호 검색 버튼 서브타이틀",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Find route by route number keyword"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -525,8 +1820,14 @@
     },
     "test.ui.button.searchRoute.title" : {
       "comment" : "테스트: 노선 번호 검색 버튼 타이틀",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Route Number Search"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -537,8 +1838,14 @@
     },
     "test.ui.button.searchStop.subtitle" : {
       "comment" : "테스트: 정류장 키워드 검색 버튼 서브타이틀",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Search by city code and stop name"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -549,8 +1856,14 @@
     },
     "test.ui.button.searchStop.title" : {
       "comment" : "테스트: 정류장 키워드 검색 버튼 타이틀",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stop Keyword Search"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -561,8 +1874,14 @@
     },
     "test.ui.button.stopRoutes.subtitle" : {
       "comment" : "테스트: 정류장을 지나는 노선 버튼 서브타이틀",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "List of routes passing through selected stop"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -573,8 +1892,14 @@
     },
     "test.ui.button.stopRoutes.title" : {
       "comment" : "테스트: 정류장을 지나는 노선 버튼 타이틀",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Routes Through Stop"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -585,8 +1910,14 @@
     },
     "test.ui.button.stopsByGps.subtitle" : {
       "comment" : "테스트: 현위치 주변 정류장 버튼 서브타이틀",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Radius search based on current coordinates"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -597,8 +1928,14 @@
     },
     "test.ui.button.stopsByGps.title" : {
       "comment" : "테스트: 현위치 주변 정류장 버튼 타이틀",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nearby Stops (Current Location)"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -609,8 +1946,14 @@
     },
     "test.ui.label.apiCall" : {
       "comment" : "테스트: API 호출 섹션 타이틀",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Test API Calls"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -621,8 +1964,14 @@
     },
     "test.ui.label.cityCode" : {
       "comment" : "테스트: cityCode 레이블",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "cityCode"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -633,8 +1982,14 @@
     },
     "test.ui.label.coordinates" : {
       "comment" : "테스트: 위도/경도 레이블",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Latitude/Longitude"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -645,8 +2000,14 @@
     },
     "test.ui.label.nodeId" : {
       "comment" : "테스트: nodeId 레이블",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "nodeId"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -657,8 +2018,14 @@
     },
     "test.ui.label.rawResponse" : {
       "comment" : "테스트: 원본 응답 레이블",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Raw Response (JSON)"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -669,8 +2036,14 @@
     },
     "test.ui.label.responsePreview" : {
       "comment" : "테스트: 응답 미리보기 레이블",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Response Preview"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -681,8 +2054,14 @@
     },
     "test.ui.label.route" : {
       "comment" : "테스트: 노선 레이블",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Route ID/Route Number"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -693,8 +2072,14 @@
     },
     "test.ui.label.searchTerm" : {
       "comment" : "테스트: 검색어 레이블",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Search Term"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -703,10 +2088,33 @@
         }
       }
     },
+    "test.ui.picker.profile" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Test Profile"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "테스트 프로필"
+          }
+        }
+      }
+    },
     "test.ui.placeholder.noSearchTerm" : {
       "comment" : "테스트: 검색어 없음 플레이스홀더",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No search term"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -715,10 +2123,50 @@
         }
       }
     },
+    "test.ui.profile.pangyo" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pangyo"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "판교"
+          }
+        }
+      }
+    },
+    "test.ui.profile.seoul" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seoul"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "서울"
+          }
+        }
+      }
+    },
     "test.ui.title.arrivalSection" : {
       "comment" : "테스트: 도착 정보 섹션 타이틀",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Arrival Information"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -729,8 +2177,14 @@
     },
     "test.ui.title.navigation" : {
       "comment" : "테스트: 내비게이션 타이틀",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bus API Test"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -741,8 +2195,14 @@
     },
     "test.ui.title.routeSection" : {
       "comment" : "테스트: 노선 정보 섹션 타이틀",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Route Information"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -751,10 +2211,33 @@
         }
       }
     },
+    "test.ui.title.seoulSection" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seoul API Tests"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seoul API Tests"
+          }
+        }
+      }
+    },
     "test.ui.title.stopSection" : {
       "comment" : "테스트: 정류장 조회 섹션 타이틀",
-      "extractionState" : "stale",
+      "extractionState" : "manual",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stop Search"
+          }
+        },
         "ko" : {
           "stringUnit" : {
             "state" : "translated",
@@ -764,112 +2247,26 @@
       }
     },
     "가장 가까운 정류장은 **%@** 입니다. 맞습니까?" : {
-
-    },
-    "네, 맞아요." : {
-
-    },
-    "노선 번호를 선택하세요." : {
-
-    },
-    "다른 번호의 버스입니다." : {
-
-    },
-    "도착 예정" : {
-
-    },
-    "도착 예정 정보 없음" : {
-
-    },
-    "마이크 접근" : {
-
-    },
-    "몇 번 버스를\n탑승하시나요?" : {
-
-    },
-    "몇번 버스를 탑승하시나요?" : {
-
-    },
-    "목록에 없어요." : {
-
-    },
-    "버스 번호 인식을 위해 사용" : {
-
-    },
-    "버스 인식 중" : {
-
-    },
-    "버스 인식하기" : {
-
-    },
-    "버스 찾기" : {
-
-    },
-    "버스가 직전 정류장에서 출발하면\n버스 인식을 시작할 수 있어요." : {
-
-    },
-    "버스온다를 사용하고 정보를\n위치, 카메라 및 마이크 접근을 허용해 주세요." : {
-
-    },
-    "버스온다에 접근\n권한이 필요합니다." : {
-
-    },
-    "번이 맞나요?" : {
-
-    },
-    "번호를 듣는중이에요." : {
-
-    },
-    "사용자 위치 기반 정류장 안내를 위해 사용" : {
-
-    },
-    "설정으로 이동" : {
-
-    },
-    "아니오" : {
-
-    },
-    "아니요, 다시 인식할게요" : {
-
-    },
-    "아니요, 목록에서 고를게요" : {
-
-    },
-    "예" : {
-
-    },
-    "위치 정보 접근" : {
-
-    },
-    "음성 검색 기능을 위해 사용" : {
-
-    },
-    "재시도" : {
-
-    },
-    "주변 정류장 찾기" : {
-
-    },
-    "주변 탐색된 정류장이\n없습니다." : {
-
-    },
-    "주변에 정류장이 없습니다." : {
-
-    },
-    "카메라 접근" : {
-
-    },
-    "타려는 버스 번호가\n" : {
-
-    },
-    "현재 운행중인 버스 위치:" : {
-
-    },
-    "현재 위치를 기반으로 버스 정보를 검색합니다." : {
-
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "The nearest stop is **%@**. Is this correct?"
+          }
+        }
+      }
     },
     "현재 주변 정류장은\n" : {
-
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nearby stops are\n"
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/OffStageApp/Sources/Presentation/BusVision/QuickCameraView.swift
+++ b/OffStageApp/Sources/Presentation/BusVision/QuickCameraView.swift
@@ -25,7 +25,9 @@ struct QuickCameraView: View {
                 if isRouteNumEntered {
                     #if DEBUG_MODE
                         if busDetectedState == .unDetected {
-                            Text("\(routeNumbers.first!)번 탐지중")
+                            if let first = routeNumbers.first {
+                                Text(String(format: "busVision.debug.detectingWithNumber", arguments: [first]))
+                            }
                         }
                     #endif
                     // 탐지 결과

--- a/OffStageApp/Sources/Presentation/BusVision/SubViews/DetectingStatusSubView.swift
+++ b/OffStageApp/Sources/Presentation/BusVision/SubViews/DetectingStatusSubView.swift
@@ -8,7 +8,7 @@ struct DetectingStatusSubView: View {
         VStack {
             switch status {
             case .unDetected:
-                Text("버스 인식 중")
+                Text(L10n.BusVision.Detection.inProgress)
                     .font(.title)
                     .fontWeight(.bold)
 
@@ -16,7 +16,7 @@ struct DetectingStatusSubView: View {
                     .frame(height: 20)
 
             case .notMine:
-                Text("다른 번호의 버스입니다.")
+                Text(L10n.BusVision.Detection.wrongBusNumber)
                     .font(.title)
                     .fontWeight(.bold)
 

--- a/OffStageApp/Sources/Presentation/BusVision/SubViews/FastBusVisionInputView.swift
+++ b/OffStageApp/Sources/Presentation/BusVision/SubViews/FastBusVisionInputView.swift
@@ -5,7 +5,7 @@ struct FastBusVisionInputView: View {
     let onSubmit: () -> Void
 
     var body: some View {
-        Text("몇번 버스를 탑승하시나요?")
+        Text(L10n.Home.Stt.askBusNumberSimple)
             .font(.system(size: 21, weight: .semibold))
 
         TextField("탑승할 버스번호", text: $routeNumber)

--- a/OffStageApp/Sources/Presentation/Common/L10n.swift
+++ b/OffStageApp/Sources/Presentation/Common/L10n.swift
@@ -9,7 +9,58 @@ enum L10n {
         LocalizedStringKey(key)
     }
 
+    enum Bus {
+        enum Arrival {
+            /// "현재 운행중인 버스 위치:"
+            static let currentBusLocation = key("bus.arrival.currentBusLocation")
+            /// "도착 예정"
+            static let imminent = key("bus.arrival.imminent")
+            /// "도착 예정 정보 없음"
+            static let noInformation = key("bus.arrival.noInformation")
+
+            /// "현재는 운행중인 노선이 없습니다."
+            static let noOperatingRoutes = key("bus.arrival.noOperatingRoutes")
+
+            enum Error {
+                /// "도착 정보를 불러오는 데 실패했습니다: %@"
+                static let loadFailed = key("bus.arrival.error.loadFailed")
+            }
+        }
+    }
+
+    enum BusVision {
+        enum Detection {
+            /// "번이 맞나요?"
+            static let confirmBusNumber = key("busVision.detection.confirmBusNumber")
+            /// "타려는 버스 번호가\\n"
+            static let confirmBusNumberPrefix = key("busVision.detection.confirmBusNumberPrefix")
+
+            /// "버스 인식 중"
+            static let inProgress = key("busVision.detection.inProgress")
+            /// "아니요, 다시 인식할게요"
+            static let retry = key("busVision.detection.retry")
+            /// "아니요, 목록에서 고를게요"
+            static let selectFromList = key("busVision.detection.selectFromList")
+            /// "다른 번호의 버스입니다."
+            static let wrongBusNumber = key("busVision.detection.wrongBusNumber")
+        }
+
+        enum Debug {
+            /// "%@번 탐지중" (문맥: 버스비전: 디버그 탐지 상태)
+            static let detectingWithNumber = key("busVision.debug.detectingWithNumber")
+        }
+    }
+
     enum Common {
+        enum Confirmation {
+            /// "아니오"
+            static let no = key("common.confirmation.no")
+            /// "네, 맞아요."
+            static let yes = key("common.confirmation.yes")
+            /// "예"
+            static let yesShort = key("common.confirmation.yesShort")
+        }
+
         enum Ui {
             /// "취소" (문맥: 공용: 취소 버튼)
             static let buttonCancel = key("common.ui.button.cancel")
@@ -25,6 +76,12 @@ enum L10n {
 
             /// "저장" (문맥: 공용: 저장 버튼)
             static let buttonSave = key("common.ui.button.save")
+
+            /// " 입니다."
+            static let suffixIs = key("common.ui.suffix.is")
+
+            /// "알 수 없는 위치" (문맥: 공용: 위치 정보 미확인 시 표시)
+            static let unknownLocation = key("common.ui.unknownLocation")
         }
     }
 
@@ -44,31 +101,166 @@ enum L10n {
 
             /// "Debug" (문맥: 디버그: 화면 타이틀)
             static let title = key("debug.ui.title")
+
+            /// "API Flow" (문맥: 디버그: MVP 테스트 내비게이션 타이틀)
+            static let titleApiFlow = key("debug.ui.title.apiFlow")
+
+            /// "L10n Test" (문맥: 디버그: L10n 테스트 화면 타이틀)
+            static let titleL10nTest = key("debug.ui.title.l10nTest")
+
+            /// "Switch to English" (문맥: 디버그: 언어 전환 토글 레이블)
+            static let toggleSwitchToEnglish = key("debug.ui.toggle.switchToEnglish")
+        }
+
+        enum Mvp {
+            /// "예: 441" (문맥: 디버그: 노선 입력 예시)
+            static let placeholderRouteExample = key("debug.mvp.placeholder.routeExample")
+
+            /// "**%@** 정류장을 통과하는 버스 번호를 입력하세요." (문맥: 디버그: 노선 입력 안내)
+            static let promptEnterRouteForStop = key("debug.mvp.prompt.enterRouteForStop")
         }
     }
 
     enum Home {
-        enum Ui {
-            /// "나의 버스 추가하기" (문맥: 홈 화면: 즐겨찾기 비어있을 때 추가 버튼)
-            static let emptyButtonAdd = key("home.ui.empty.button.add")
+        enum Button {
+            /// "버스 찾기"
+            static let findBus = key("home.button.findBus")
+            /// "주변 정류장 찾기"
+            static let findNearbyStops = key("home.button.findNearbyStops")
+        }
 
-            /// "자주 이용하는 버스를 추가해 주세요." (문맥: 홈 화면: 즐겨찾기 비어있을 때 부제목)
-            static let emptySubtitle = key("home.ui.empty.subtitle")
+        enum Map {
+            /// "%@ 인근"
+            static let near = key("home.map.near")
+            /// "주변 탐색된 정류장이\\n없습니다."
+            static let noStopsFound = key("home.map.noStopsFound")
+            /// "주변에 정류장이 없습니다."
+            static let noStopsFoundSimple = key("home.map.noStopsFound.simple")
+        }
 
-            /// "저장된 내역이 없습니다." (문맥: 홈 화면: 즐겨찾기 비어있을 때 제목)
-            static let emptyTitle = key("home.ui.empty.title")
+        enum Sheet {
+            /// "버스가 두번째 전 정류장에서 출발하면\\n버스 인식을 시작할 수 있어요."
+            static let busDetectionGuide = key("home.sheet.busDetectionGuide")
+            /// "목록에 없어요."
+            static let notFound = key("home.sheet.notFound")
+            /// "노선 번호를 선택하세요."
+            static let selectBusRoute = key("home.sheet.selectBusRoute")
+            /// "버스 인식하기"
+            static let startBusDetection = key("home.sheet.startBusDetection")
+        }
 
-            /// "버스 노선, 정류장 검색" (문맥: 홈 화면: 검색창 플레이스홀더)
-            static let placeholderSearch = key("home.ui.placeholder.search")
+        enum Stt {
+            /// "몇 번 버스를\\n탑승하시나요?"
+            static let askBusNumber = key("home.stt.askBusNumber")
+            /// "몇번 버스를 탑승하시나요?"
+            static let askBusNumberSimple = key("home.stt.askBusNumberSimple")
+            /// "가장 가까운 정류장은 **%@** 입니다. 맞습니까?"
+            static let confirmNearestStop = key("home.stt.confirmNearestStop")
+            /// "현재 주변 정류장은\\n"
+            static let currentNearbyStopPrefix = key("home.stt.currentNearbyStopPrefix")
+            /// "번호를 듣는중이에요."
+            static let listening = key("home.stt.listening")
 
-            /// "홈" (문맥: 홈 화면: 내비게이션 타이틀)
-            static let title = key("home.ui.title")
+            /// "현재 위치를 기반으로 버스 정보를 검색합니다."
+            static let searchBasedOnLocation = key("home.stt.searchBasedOnLocation")
+        }
+
+        enum A11y {
+            enum Button {
+                enum Mic {
+                    /// "타야할 버스 번호 음성 입력 버튼"
+                    static let label = key("home.a11y.button.mic.label")
+
+                    enum Hint {
+                        /// "아직 주변 정류장을 찾는 중입니다. 잠시만 기다려주세요."
+                        static let loading = key("home.a11y.button.mic.hint.loading")
+                        /// "주변 정류장을 찾지 못했습니다. 위치 권한을 확인하거나 다시 시도해 주세요."
+                        static let noStop = key("home.a11y.button.mic.hint.noStop")
+                        /// "음성으로 타야할 버스를 검색하려면 두 번 탭해주세요."
+                        static let ready = key("home.a11y.button.mic.hint.ready")
+                    }
+                }
+            }
+
+            enum Announcement {
+                /// "주변 정류장 정보를 불러오고 있습니다."
+                static let loading = key("home.a11y.announcement.loading")
+                /// "근처 정류장 정보를 불러오고 있습니다."
+                static let loadingNearby = key("home.a11y.announcement.loadingNearby")
+            }
+        }
+
+        enum Ui {}
+    }
+
+    enum Permission {
+        enum Button {
+            /// "설정으로 이동"
+            static let goToSettings = key("permission.button.goToSettings")
+        }
+
+        enum Camera {
+            /// "버스 번호 인식을 위해 사용"
+            static let reason = key("permission.camera.reason")
+            /// "카메라 접근"
+            static let title = key("permission.camera.title")
+        }
+
+        enum Location {
+            /// "사용자 위치 기반 정류장 안내를 위해 사용"
+            static let reason = key("permission.location.reason")
+            /// "위치 정보 접근"
+            static let title = key("permission.location.title")
+        }
+
+        enum Mic {
+            /// "음성 검색 기능을 위해 사용"
+            static let reason = key("permission.mic.reason")
+            /// "마이크 접근"
+            static let title = key("permission.mic.title")
+        }
+
+        enum Prompt {
+            /// "버스온다를 사용하고 정보를\\n위치, 카메라 및 마이크 접근을 허용해 주세요."
+            static let all = key("permission.prompt.all")
+            /// "버스온다에 접근\\n권한이 필요합니다."
+            static let title = key("permission.prompt.title")
+        }
+
+        enum A11y {
+            enum Status {
+                /// "거절됨"
+                static let denied = key("permission.a11y.status.denied")
+                /// "승인됨"
+                static let granted = key("permission.a11y.status.granted")
+            }
         }
     }
 
-    enum K {
-        /// "버스온다" (문맥: 앱의 공식 이름)
-        static let appName = key("k.appName")
+    // Accessibility-only formats for BusArrival screens
+    enum BusArrival {
+        enum A11y {
+            enum Format {
+                /// "%@번"
+                static let routeNumber = key("busArrival.a11y.format.routeNumber")
+                /// "도착 예정"
+                static let arriving = key("busArrival.a11y.format.arriving")
+                /// "도착"
+                static let arrived = key("busArrival.a11y.format.arrived")
+                /// "%@번째전 정류장에서 출발했습니다."
+                static let stopsAway = key("busArrival.a11y.format.stopsAway")
+                /// "전 정류장에서 출발했습니다."
+                static let previousStop = key("busArrival.a11y.format.previousStop")
+                /// "잠시 후"
+                static let soon = key("busArrival.a11y.format.soon")
+                /// "정보 없음"
+                static let noInfo = key("busArrival.a11y.format.noInfo")
+                /// "%@분 %@초 후"
+                static let minutesSeconds = key("busArrival.a11y.format.minutesSeconds")
+                /// "%@초 후"
+                static let seconds = key("busArrival.a11y.format.seconds")
+            }
+        }
     }
 
     enum SttTtsTest {
@@ -199,6 +391,18 @@ enum L10n {
 
             /// "정류장 조회" (문맥: 테스트: 정류장 조회 섹션 타이틀)
             static let titleStopSection = key("test.ui.title.stopSection")
+
+            /// "Seoul API Tests" (문맥: 테스트: 서울 API 테스트 섹션 타이틀)
+            static let titleSeoulSection = key("test.ui.title.seoulSection")
+
+            /// "Test Profile" (문맥: 테스트: 프로필 선택 라벨)
+            static let pickerProfile = key("test.ui.picker.profile")
+
+            /// "Seoul" (문맥: 테스트: 프로필 이름)
+            static let profileSeoul = key("test.ui.profile.seoul")
+
+            /// "Pangyo" (문맥: 테스트: 프로필 이름)
+            static let profilePangyo = key("test.ui.profile.pangyo")
         }
     }
 }

--- a/OffStageApp/Sources/Presentation/Debug/DebugView.swift
+++ b/OffStageApp/Sources/Presentation/Debug/DebugView.swift
@@ -10,6 +10,10 @@
             NavigationView {
                 List {
                     NavigationLink(
+                        "L10n Test View",
+                        destination: L10nTestView()
+                    )
+                    NavigationLink(
                         L10n.Debug.Ui.linkBusVision,
                         destination: BusVisionView(routeNumbers: ["207", "306"])
                     )

--- a/OffStageApp/Sources/Presentation/Debug/L10nTestView.swift
+++ b/OffStageApp/Sources/Presentation/Debug/L10nTestView.swift
@@ -1,0 +1,132 @@
+#if DEBUG_MODE
+    import SwiftUI
+
+    struct L10nTestView: View {
+        @State private var language = "ko"
+
+        var body: some View {
+            VStack {
+                Toggle(isOn: Binding(
+                    get: { language == "en" },
+                    set: { language = $0 ? "en" : "ko" }
+                )) {
+                    Text(L10n.Debug.Ui.toggleSwitchToEnglish)
+                }
+                .padding()
+
+                List {
+                    Section("Bus") {
+                        Text(L10n.Bus.Arrival.currentBusLocation)
+                        Text(L10n.Bus.Arrival.imminent)
+                        Text(L10n.Bus.Arrival.noInformation)
+                    }
+                    Section("BusVision") {
+                        Text(L10n.BusVision.Detection.confirmBusNumber)
+                        Text(L10n.BusVision.Detection.confirmBusNumberPrefix)
+
+                        Text(L10n.BusVision.Detection.inProgress)
+                        Text(L10n.BusVision.Detection.retry)
+                        Text(L10n.BusVision.Detection.selectFromList)
+                        Text(L10n.BusVision.Detection.wrongBusNumber)
+                    }
+                    Section("Common") {
+                        Text(L10n.Common.Confirmation.no)
+                        Text(L10n.Common.Confirmation.yes)
+                        Text(L10n.Common.Confirmation.yesShort)
+                        Text(L10n.Common.Ui.buttonCancel)
+                        Text(L10n.Common.Ui.buttonNext)
+                        Text(L10n.Common.Ui.buttonPrevious)
+                        Text(L10n.Common.Ui.buttonRetry)
+                        Text(L10n.Common.Ui.buttonSave)
+                        Text(L10n.Common.Ui.suffixIs)
+                    }
+                    Section("Debug") {
+                        Text(L10n.Debug.Ui.buttonApiTest)
+                        Text(L10n.Debug.Ui.buttonClear)
+                        Text(L10n.Debug.Ui.buttonSttTtsTest)
+                        Text(L10n.Debug.Ui.linkBusVision)
+                        Text(L10n.Debug.Ui.title)
+                    }
+                    Section("Home") {
+                        Text(L10n.Home.Button.findBus)
+                        Text(L10n.Home.Button.findNearbyStops)
+                        Text(L10n.Home.Map.near)
+                        Text(L10n.Home.Map.noStopsFound)
+                        Text(L10n.Home.Map.noStopsFoundSimple)
+                        Text(L10n.Home.Sheet.busDetectionGuide)
+                        Text(L10n.Home.Sheet.notFound)
+                        Text(L10n.Home.Sheet.selectBusRoute)
+                        Text(L10n.Home.Sheet.startBusDetection)
+                        Text(L10n.Home.Stt.askBusNumber)
+                        Text(L10n.Home.Stt.askBusNumberSimple)
+                        Text(L10n.Home.Stt.confirmNearestStop)
+                        Text(L10n.Home.Stt.currentNearbyStopPrefix)
+                        Text(L10n.Home.Stt.listening)
+
+                        Text(L10n.Home.Stt.searchBasedOnLocation)
+                    }
+
+                    Section("Permission") {
+                        Text(L10n.Permission.Button.goToSettings)
+                        Text(L10n.Permission.Camera.reason)
+                        Text(L10n.Permission.Camera.title)
+                        Text(L10n.Permission.Location.reason)
+                        Text(L10n.Permission.Location.title)
+                        Text(L10n.Permission.Mic.reason)
+                        Text(L10n.Permission.Mic.title)
+                        Text(L10n.Permission.Prompt.all)
+                        Text(L10n.Permission.Prompt.title)
+                    }
+
+                    Section("SttTtsTest") {
+                        Text(L10n.SttTtsTest.Ui.buttonDismissKeyboard)
+                        Text(L10n.SttTtsTest.Ui.buttonRead)
+                        Text(L10n.SttTtsTest.Ui.buttonStartListening)
+                        Text(L10n.SttTtsTest.Ui.buttonStop)
+                        Text(L10n.SttTtsTest.Ui.buttonStopListening)
+                        Text(L10n.SttTtsTest.Ui.placeholderStt)
+                        Text(L10n.SttTtsTest.Ui.placeholderTts)
+                        Text(L10n.SttTtsTest.Ui.titleNavigation)
+                        Text(L10n.SttTtsTest.Ui.titleStt)
+                        Text(L10n.SttTtsTest.Ui.titleTts)
+                    }
+                    Section("Test") {
+                        Text(L10n.Test.Ui.buttonArrivalsSubtitle)
+                        Text(L10n.Test.Ui.buttonArrivalsTitle)
+                        Text(L10n.Test.Ui.buttonArrivalsForRouteSubtitle)
+                        Text(L10n.Test.Ui.buttonArrivalsForRouteTitle)
+                        Text(L10n.Test.Ui.buttonRouteBusLocationsSubtitle)
+                        Text(L10n.Test.Ui.buttonRouteBusLocationsTitle)
+                        Text(L10n.Test.Ui.buttonRouteInfoSubtitle)
+                        Text(L10n.Test.Ui.buttonRouteInfoTitle)
+                        Text(L10n.Test.Ui.buttonRouteStopsSubtitle)
+                        Text(L10n.Test.Ui.buttonRouteStopsTitle)
+                        Text(L10n.Test.Ui.buttonSearchRouteSubtitle)
+                        Text(L10n.Test.Ui.buttonSearchRouteTitle)
+                        Text(L10n.Test.Ui.buttonSearchStopSubtitle)
+                        Text(L10n.Test.Ui.buttonSearchStopTitle)
+                        Text(L10n.Test.Ui.buttonStopRoutesSubtitle)
+                        Text(L10n.Test.Ui.buttonStopRoutesTitle)
+                        Text(L10n.Test.Ui.buttonStopsByGpsSubtitle)
+                        Text(L10n.Test.Ui.buttonStopsByGpsTitle)
+                        Text(L10n.Test.Ui.labelApiCall)
+                        Text(L10n.Test.Ui.labelCityCode)
+                        Text(L10n.Test.Ui.labelCoordinates)
+                        Text(L10n.Test.Ui.labelNodeId)
+                        Text(L10n.Test.Ui.labelRawResponse)
+                        Text(L10n.Test.Ui.labelResponsePreview)
+                        Text(L10n.Test.Ui.labelRoute)
+                        Text(L10n.Test.Ui.labelSearchTerm)
+                        Text(L10n.Test.Ui.placeholderNoSearchTerm)
+                        Text(L10n.Test.Ui.titleArrivalSection)
+                        Text(L10n.Test.Ui.titleNavigation)
+                        Text(L10n.Test.Ui.titleRouteSection)
+                        Text(L10n.Test.Ui.titleStopSection)
+                    }
+                }
+                .environment(\.locale, .init(identifier: language))
+            }
+            .navigationTitle(L10n.Debug.Ui.titleL10nTest)
+        }
+    }
+#endif

--- a/OffStageApp/Sources/Presentation/Debug/SubView/MVPTestView.swift
+++ b/OffStageApp/Sources/Presentation/Debug/SubView/MVPTestView.swift
@@ -31,7 +31,7 @@ struct MVPTestView: View {
             .padding(.vertical, 24)
         }
         .background(Color(.systemGroupedBackground).ignoresSafeArea())
-        .navigationTitle("API Flow")
+        .navigationTitle(L10n.Debug.Ui.titleApiFlow)
         .navigationBarTitleDisplayMode(.inline)
         .overlay(
             ActivityIndicator(isAnimating: loadingBinding, style: .large)
@@ -49,7 +49,7 @@ struct MVPTestView: View {
 
     private var initialStepView: some View {
         VStack(spacing: 12) {
-            Text("현재 위치를 기반으로 버스 정보를 검색합니다.")
+            Text(L10n.Home.Stt.searchBasedOnLocation)
                 .font(.headline)
             Button {
                 Task {
@@ -58,7 +58,7 @@ struct MVPTestView: View {
                     }
                 }
             } label: {
-                Text("주변 정류장 찾기")
+                Text(L10n.Home.Button.findNearbyStops)
                     .font(.headline)
                     .frame(maxWidth: .infinity)
             }
@@ -71,13 +71,13 @@ struct MVPTestView: View {
     private func stopSelectionStepView(stops: [BusStop]) -> some View {
         VStack(spacing: 16) {
             if let closest = stops.first {
-                Text("가장 가까운 정류장은 **\(closest.name)** 입니다. 맞습니까?")
+                Text(String(format: String(localized: "home.stt.confirmNearestStop"), closest.name))
                     .font(.headline)
                 HStack(spacing: 12) {
                     Button {
                         step = .stopConfirmed(closest)
                     } label: {
-                        Text("예")
+                        Text(L10n.Common.Confirmation.yesShort)
                             .font(.headline)
                             .frame(maxWidth: .infinity)
                     }
@@ -88,7 +88,7 @@ struct MVPTestView: View {
                         // TODO: Show a list of other stops to choose from
                         step = .initial
                     } label: {
-                        Text("아니오")
+                        Text(L10n.Common.Confirmation.no)
                             .font(.headline)
                             .frame(maxWidth: .infinity)
                     }
@@ -96,8 +96,8 @@ struct MVPTestView: View {
                     .controlSize(.large)
                 }
             } else {
-                Text("주변에 정류장이 없습니다.")
-                Button("다시 시도") {
+                Text(L10n.Home.Map.noStopsFoundSimple)
+                Button(L10n.Common.Ui.buttonRetry) {
                     step = .initial
                 }
                 .buttonStyle(.bordered)
@@ -109,10 +109,10 @@ struct MVPTestView: View {
 
     private func routeInputStepView(stop: BusStop) -> some View {
         VStack(alignment: .leading, spacing: 12) {
-            Text("**\(stop.name)** 정류장을 통과하는 버스 번호를 입력하세요.")
+            Text(String(format: String(localized: "debug.mvp.prompt.enterRouteForStop"), stop.name))
                 .font(.headline)
 
-            TextField("e.g., 441", text: $viewModel.routeQuery)
+            TextField(L10n.Debug.Mvp.placeholderRouteExample, text: $viewModel.routeQuery)
                 .textFieldStyle(.roundedBorder)
                 .keyboardType(.numberPad)
 
@@ -122,7 +122,7 @@ struct MVPTestView: View {
                     await viewModel.findBusFor(stop: stop, routeQuery: viewModel.routeQuery)
                 }
             } label: {
-                Text("버스 찾기")
+                Text(L10n.Home.Button.findBus)
                     .font(.headline)
                     .frame(maxWidth: .infinity)
             }

--- a/OffStageApp/Sources/Presentation/Debug/SubView/TestView.swift
+++ b/OffStageApp/Sources/Presentation/Debug/SubView/TestView.swift
@@ -15,9 +15,9 @@ struct TestView: View {
         NavigationView {
             ScrollView {
                 VStack(spacing: 24) {
-                    Picker("Test Profile", selection: $selectedProfile) {
+                    Picker(L10n.Test.Ui.pickerProfile, selection: $selectedProfile) {
                         ForEach(TestProfile.allCases) { profile in
-                            Text(profile.rawValue).tag(profile)
+                            Text(localizedProfileName(profile)).tag(profile)
                         }
                     }
                     .pickerStyle(.segmented)
@@ -32,13 +32,13 @@ struct TestView: View {
 //                    }
 
                     Section(
-                        header: Text("API Calls")
+                        header: Text(L10n.Test.Ui.labelApiCall)
                     ) {
                         actionSection
                     }
 
                     Section(
-                        header: Text("API Response")
+                        header: Text(L10n.Test.Ui.labelResponsePreview)
                     ) {
                         responseSection
                     }
@@ -138,7 +138,7 @@ struct TestView: View {
                 .font(.headline)
 
             if selectedProfile == .seoul {
-                actionGroup(title: "Seoul API Tests", actions: seoulAPIActions)
+                actionGroup(title: L10n.Test.Ui.titleSeoulSection, actions: seoulAPIActions)
             } else {
                 actionGroup(title: L10n.Test.Ui.titleStopSection, actions: stopActions)
                 actionGroup(title: L10n.Test.Ui.titleArrivalSection, actions: arrivalActions)
@@ -196,6 +196,15 @@ struct TestView: View {
             get: { viewModel.isLoading },
             set: { viewModel.isLoading = $0 }
         )
+    }
+
+    private func localizedProfileName(_ profile: TestProfile) -> LocalizedStringKey {
+        switch profile {
+        case .seoul:
+            L10n.Test.Ui.profileSeoul
+        case .nonSeoul:
+            L10n.Test.Ui.profilePangyo
+        }
     }
 
     private var stopActions: [APIAction] {

--- a/OffStageApp/Sources/Presentation/Home/HomeView.swift
+++ b/OffStageApp/Sources/Presentation/Home/HomeView.swift
@@ -23,7 +23,7 @@ struct HomeView: View {
             VStack(spacing: 0) {
                 stopInfoView()
 
-                Text("몇 번 버스를\n탑승하시나요?")
+                Text(L10n.Home.Stt.askBusNumber)
                     .font(.title)
                     .fontWeight(.bold)
                     .multilineTextAlignment(.center)
@@ -83,7 +83,10 @@ struct HomeView: View {
             // TODO:
             // - 짧은 시간에 공지가 연속 게시되면 이전 멘트를 중단하고 새 멘트를 읽어 "문장이 씹히는" 현상이 발생함
             if isLoading {
-                UIAccessibility.post(notification: .announcement, argument: "근처 정류장 정보를 불러오고 있습니다.")
+                UIAccessibility.post(
+                    notification: .announcement,
+                    argument: String(localized: "home.a11y.announcement.loadingNearby")
+                )
             }
         }
     }
@@ -95,14 +98,14 @@ struct HomeView: View {
                 .progressViewStyle(CircularProgressViewStyle(tint: .white))
                 .frame(height: 60)
                 .padding(.horizontal)
-                .accessibilityLabel("주변 정류장 정보를 불러오고 있습니다.")
+                .accessibilityLabel(Text(L10n.Home.A11y.Announcement.loading))
         } else if let stop = viewModel.nearestBusStop {
             HStack {
-                (Text("현재 주변 정류장은\n") +
+                (Text(L10n.Home.Stt.currentNearbyStopPrefix) +
                     Text(stop.name)
                     .foregroundColor(Color(.primarynormal))
                     .fontWeight(.bold) +
-                    Text(" 입니다.")
+                    Text(L10n.Common.Ui.suffixIs)
                 )
                 .font(.title3)
                 .fontWeight(.semibold)
@@ -120,7 +123,7 @@ struct HomeView: View {
         } else {
             VStack(spacing: 10) {
                 HStack {
-                    Text("주변 탐색된 정류장이\n없습니다.")
+                    Text(L10n.Home.Map.noStopsFound)
                         .font(.headline)
                         .multilineTextAlignment(.leading)
                         .foregroundColor(.white)
@@ -132,7 +135,7 @@ struct HomeView: View {
                 Button {
                     viewModel.fetchNearestStop()
                 } label: {
-                    Text("재시도")
+                    Text(L10n.Common.Ui.buttonRetry)
                         .font(.headline)
                         .foregroundColor(.white)
                         .padding(.vertical, 8)
@@ -171,18 +174,18 @@ struct HomeView: View {
         }
         .disabled(isMicDisabled)
         .opacity(isMicDisabled ? 0.4 : 1.0)
-        .accessibilityLabel("타야할 버스 번호 음성 입력 버튼")
-        .accessibilityHint(
-            {
+        .accessibilityLabel(Text(L10n.Home.A11y.Button.Mic.label))
+        .accessibilityHint({
+            let hintKey: LocalizedStringKey = {
                 if viewModel.isLoading {
-                    return "아직 주변 정류장을 찾는 중입니다. 잠시만 기다려주세요."
+                    return L10n.Home.A11y.Button.Mic.Hint.loading
                 }
-                // 로딩이 아니고 정류장 데이터가 없는 경우
                 if viewModel.nearestBusStop == nil {
-                    return "주변 정류장을 찾지 못했습니다. 위치 권한을 확인하거나 다시 시도해 주세요."
+                    return L10n.Home.A11y.Button.Mic.Hint.noStop
                 }
-                return "음성으로 타야할 버스를 검색하려면 두 번 탭해주세요."
+                return L10n.Home.A11y.Button.Mic.Hint.ready
             }()
-        )
+            return Text(hintKey)
+        }())
     }
 }

--- a/OffStageApp/Sources/Presentation/Home/SubView/BusArrivalView.swift
+++ b/OffStageApp/Sources/Presentation/Home/SubView/BusArrivalView.swift
@@ -37,7 +37,7 @@ struct BusArrivalView: View {
             Spacer()
             VStack(alignment: .center, spacing: 10) {
                 // Callout/Emphasized
-                Text("버스가 두번째 전 정류장에서 출발하면\n버스 인식을 시작할 수 있어요.")
+                Text(L10n.Home.Sheet.busDetectionGuide)
                     .font(.callout)
                     .foregroundColor(.white.opacity(0.7))
                     .multilineTextAlignment(.center)
@@ -49,7 +49,7 @@ struct BusArrivalView: View {
                 }) {
                     HStack {
                         Image(systemName: "camera")
-                        Text("버스 인식하기")
+                        Text(L10n.Home.Sheet.startBusDetection)
                     }
                     .font(.title3)
                     .fontWeight(.semibold)
@@ -98,37 +98,48 @@ struct BusArrivalView: View {
         currentEstimatedArrivalTime: Int?,
         busUrgencyStatus: BusUrgencyStatus
     ) -> String {
+        let routeNum = String(
+            format: String(localized: "busArrival.a11y.format.routeNumber"),
+            busRoute.routeNumber
+        )
         let formattedArrivalTime = formatArrivalTime(currentEstimatedArrivalTime, busUrgencyStatus: busUrgencyStatus)
         let formattedStops = formatRemainingStops(arrival.remainingStopCount ?? 0)
 
-        if busUrgencyStatus == .arrived {
-            return "\(busRoute.routeNumber)번, \(formattedArrivalTime) 도착, \(formattedStops)"
-        }
+        let status = (busUrgencyStatus == .arrived)
+            ? String(localized: "busArrival.a11y.format.arrived")
+            : String(localized: "busArrival.a11y.format.arriving")
 
-        return "\(busRoute.routeNumber)번, \(formattedArrivalTime) 도착 예정, \(formattedStops)"
+        return "\(routeNum), \(formattedArrivalTime) \(status), \(formattedStops)"
     }
 
     private func formatRemainingStops(_ remainingStops: Int) -> String {
-        var result = ""
         if remainingStops > 1 {
-            result = "\(remainingStops)번째전"
+            String(
+                format: String(localized: "busArrival.a11y.format.stopsAway"),
+                String(remainingStops)
+            )
         } else {
-            result = "전"
+            String(localized: "busArrival.a11y.format.previousStop")
         }
-        return result + " 정류장에서 출발했습니다."
     }
 
     private func formatArrivalTime(_ seconds: Int?, busUrgencyStatus: BusUrgencyStatus) -> String {
         if busUrgencyStatus == .arrived {
-            return "잠시 후"
+            return String(localized: "busArrival.a11y.format.soon")
         }
-        guard let seconds else { return "정보 없음" }
+        guard let seconds else { return String(localized: "busArrival.a11y.format.noInfo") }
         let minutes = seconds / 60
         let remainingSeconds = seconds % 60
         if minutes >= 1 {
-            return "\(minutes)분 \(remainingSeconds)초 후"
+            return String(
+                format: String(localized: "busArrival.a11y.format.minutesSeconds"),
+                String(minutes), String(remainingSeconds)
+            )
         }
-        return "\(remainingSeconds)초 후"
+        return String(
+            format: String(localized: "busArrival.a11y.format.seconds"),
+            String(remainingSeconds)
+        )
     }
 }
 
@@ -162,7 +173,7 @@ struct BusArrivalInfoView: View {
                 .fontWeight(.bold)
                 .foregroundColor(.white)
 
-            Text("도착 예정")
+            Text(L10n.Bus.Arrival.imminent)
                 .font(.title3)
                 .foregroundColor(.white.opacity(0.8))
 
@@ -172,41 +183,49 @@ struct BusArrivalInfoView: View {
                 .foregroundColor(.white.opacity(0.8))
         }
         .accessibilityElement(children: .ignore)
-        .accessibilityLabel(generateArrivalLabel())
+        .accessibilityLabel(Text(generateArrivalLabel()))
         .accessibilityAddTraits(.updatesFrequently)
     }
 
     private func generateArrivalLabel() -> String {
+        let routeNum = String(
+            format: String(localized: "busArrival.a11y.format.routeNumber"),
+            busRoute.routeNumber
+        )
         let formattedArrivalTime = formatArrivalTime(currentEstimatedArrivalTime)
         let formattedStops = formatRemainingStops(arrival.remainingStopCount ?? 0)
 
-        if busUrgencyStatus == .arrived {
-            return "\(busRoute.routeNumber)번, \(formattedArrivalTime) 도착, \(formattedStops)"
-        }
+        let status = (busUrgencyStatus == .arrived)
+            ? String(localized: "busArrival.a11y.format.arrived")
+            : String(localized: "busArrival.a11y.format.arriving")
 
-        return "\(busRoute.routeNumber)번, \(formattedArrivalTime) 도착 예정, \(formattedStops)"
+        return "\(routeNum), \(formattedArrivalTime) \(status), \(formattedStops)"
     }
 
     private func formatRemainingStops(_ remainingStops: Int) -> String {
-        var result = ""
         if remainingStops > 1 {
-            result = "\(remainingStops)번째전"
+            String(
+                format: String(localized: "busArrival.a11y.format.stopsAway"),
+                String(remainingStops)
+            )
         } else {
-            result = "전"
+            String(localized: "busArrival.a11y.format.previousStop")
         }
-        return result + " 정류장에서 출발했습니다."
     }
 
     private func formatArrivalTime(_ seconds: Int?) -> String {
-        guard let seconds else { return "정보 없음" }
+        guard let seconds else { return String(localized: "busArrival.a11y.format.noInfo") }
         let minutes = seconds / 60
         let remainingSeconds = seconds % 60
         if minutes >= 1 {
-            return "\(minutes)분 \(remainingSeconds)초 후"
+            return String(
+                format: String(localized: "busArrival.a11y.format.minutesSeconds"),
+                String(minutes), String(remainingSeconds)
+            )
         }
 
-        return "잠시 후"
-        // return "\(remainingSeconds)초 후"
+        return String(localized: "busArrival.a11y.format.soon")
+        // return String(format: String(localized: L10n.BusArrival.A11y.Format.seconds), String(remainingSeconds))
     }
 }
 
@@ -230,18 +249,22 @@ struct BusLocationInfoView: View {
             }
             .padding(.bottom, 10)
 
-            Text("도착 예정 정보 없음")
+            Text(L10n.Bus.Arrival.noInformation)
                 .font(.largeTitle)
                 .fontWeight(.bold)
                 .foregroundColor(.white)
 
-            Text("현재 운행중인 버스 위치:")
+            Text(L10n.Bus.Arrival.currentBusLocation)
                 .font(.title3)
                 .foregroundColor(.white.opacity(0.8))
 
-            Text("\(location.nodeName ?? "알 수 없는 위치") 인근")
-                .font(.title3)
-                .foregroundColor(.white.opacity(0.8))
+            let locationName = location.nodeName ?? String(localized: "common.ui.unknownLocation")
+            Text(String(
+                format: String(localized: "home.map.near"),
+                locationName
+            ))
+            .font(.title3)
+            .foregroundColor(.white.opacity(0.8))
         }
     }
 }

--- a/OffStageApp/Sources/Presentation/Home/SubView/BusArrivalViewModel.swift
+++ b/OffStageApp/Sources/Presentation/Home/SubView/BusArrivalViewModel.swift
@@ -103,12 +103,15 @@ final class BusArrivalViewModel: ObservableObject {
             currentEstimatedArrivalTime = nil
             stopCountdownTimer()
         case .empty:
-            errorMessage = "현재는 운행중인 노선이 없습니다."
+            errorMessage = String(localized: "bus.arrival.noOperatingRoutes")
             busUrgencyStatus = .notApplicable
             currentEstimatedArrivalTime = nil
             stopCountdownTimer()
         case let .error(error):
-            errorMessage = "도착 정보를 불러오는 데 실패했습니다: \(error.localizedDescription)"
+            errorMessage = String(
+                format: String(localized: "bus.arrival.error.loadFailed"),
+                error.localizedDescription
+            )
             busUrgencyStatus = .notApplicable
             currentEstimatedArrivalTime = nil
             stopCountdownTimer()

--- a/OffStageApp/Sources/Presentation/Home/SubView/BusRouteListView.swift
+++ b/OffStageApp/Sources/Presentation/Home/SubView/BusRouteListView.swift
@@ -9,7 +9,7 @@ struct BusRouteListView: View {
 
     var body: some View {
         VStack {
-            Text("노선 번호를 선택하세요.")
+            Text(L10n.Home.Sheet.selectBusRoute)
                 .font(.title)
                 .fontWeight(.bold)
                 .foregroundColor(.white)
@@ -29,7 +29,7 @@ struct BusRouteListView: View {
                     Button(action: {
                         dismiss() // Dismiss the sheet after selection
                     }) {
-                        Text("목록에 없어요.")
+                        Text(L10n.Home.Sheet.notFound)
                             .font(.title2)
                             .fontWeight(.bold)
                             .frame(maxWidth: .infinity)

--- a/OffStageApp/Sources/Presentation/Home/SubView/PermissionSubView.swift
+++ b/OffStageApp/Sources/Presentation/Home/SubView/PermissionSubView.swift
@@ -10,13 +10,13 @@ struct PermissionSubView: View {
             VStack(spacing: 24) {
                 // 헤더
                 VStack(spacing: 12) {
-                    Text("버스온다에 접근\n권한이 필요합니다.")
+                    Text(L10n.Permission.Prompt.title)
                         .font(.system(size: 32, weight: .bold))
                         .multilineTextAlignment(.center)
                         .foregroundColor(.white)
                         .padding(.bottom)
 
-                    Text("버스온다를 사용하고 정보를\n위치, 카메라 및 마이크 접근을 허용해 주세요.")
+                    Text(L10n.Permission.Prompt.all)
                         .font(.system(size: 17))
                         .multilineTextAlignment(.center)
                         .foregroundColor(.gray)
@@ -32,12 +32,18 @@ struct PermissionSubView: View {
                             .resizable()
                             .scaledToFit()
                             .frame(width: 60, height: 60)
-                            .accessibilityLabel(deniedPermissions.contains(.location) ? "거절됨" : "승인됨")
+                            .accessibilityLabel(
+                                Text(
+                                    deniedPermissions.contains(.location)
+                                        ? L10n.Permission.A11y.Status.denied
+                                        : L10n.Permission.A11y.Status.granted
+                                )
+                            )
 
                         VStack(alignment: .leading, spacing: 4) {
-                            Text("위치 정보 접근")
+                            Text(L10n.Permission.Location.title)
                                 .font(.system(size: 17))
-                            Text("사용자 위치 기반 정류장 안내를 위해 사용")
+                            Text(L10n.Permission.Location.reason)
                                 .font(.system(size: 16))
                                 .foregroundColor(.gray)
                         }
@@ -52,12 +58,18 @@ struct PermissionSubView: View {
                             .resizable()
                             .scaledToFit()
                             .frame(width: 60, height: 60)
-                            .accessibilityLabel(deniedPermissions.contains(.camera) ? "거절됨" : "승인됨")
+                            .accessibilityLabel(
+                                Text(
+                                    deniedPermissions.contains(.camera)
+                                        ? L10n.Permission.A11y.Status.denied
+                                        : L10n.Permission.A11y.Status.granted
+                                )
+                            )
 
                         VStack(alignment: .leading, spacing: 4) {
-                            Text("카메라 접근")
+                            Text(L10n.Permission.Camera.title)
                                 .font(.system(size: 17))
-                            Text("버스 번호 인식을 위해 사용")
+                            Text(L10n.Permission.Camera.reason)
                                 .font(.system(size: 16))
                                 .foregroundColor(.gray)
                         }
@@ -72,12 +84,18 @@ struct PermissionSubView: View {
                             .resizable()
                             .scaledToFit()
                             .frame(width: 60, height: 60)
-                            .accessibilityLabel(deniedPermissions.contains(.microphone) ? "거절됨" : "승인됨")
+                            .accessibilityLabel(
+                                Text(
+                                    deniedPermissions.contains(.microphone)
+                                        ? L10n.Permission.A11y.Status.denied
+                                        : L10n.Permission.A11y.Status.granted
+                                )
+                            )
 
                         VStack(alignment: .leading, spacing: 4) {
-                            Text("마이크 접근")
+                            Text(L10n.Permission.Mic.title)
                                 .font(.system(size: 17))
-                            Text("음성 검색 기능을 위해 사용")
+                            Text(L10n.Permission.Mic.reason)
                                 .font(.system(size: 16))
                                 .foregroundColor(.gray)
                         }
@@ -97,7 +115,7 @@ struct PermissionSubView: View {
                             UIApplication.shared.open(url)
                         }
                     } label: {
-                        Text("설정으로 이동")
+                        Text(L10n.Permission.Button.goToSettings)
                             .foregroundColor(.black)
                             .font(Font.custom("SF Pro", size: 20).weight(.semibold))
                             .frame(maxWidth: .infinity)

--- a/OffStageApp/Sources/Presentation/Home/SubView/SheetView.swift
+++ b/OffStageApp/Sources/Presentation/Home/SubView/SheetView.swift
@@ -34,7 +34,7 @@ struct SheetView: View {
                             .font(.largeTitle)
                             .foregroundColor(.gray.opacity(0.8))
                     }
-                    .accessibilityLabel("취소")
+                    .accessibilityLabel(L10n.Common.Ui.buttonCancel)
                 }
                 .padding()
                 .padding(.bottom, 20)
@@ -78,7 +78,7 @@ struct SheetView: View {
     @ViewBuilder
     private func listeningContent() -> some View {
         VStack {
-            Text("번호를 듣는중이에요.")
+            Text(L10n.Home.Stt.listening)
                 .font(.title)
                 .fontWeight(.bold)
                 .foregroundColor(.white)
@@ -141,11 +141,11 @@ struct SheetView: View {
     @ViewBuilder
     private func confirmationContent(recognizedBusNumber: String) -> some View {
         VStack {
-            (Text("타려는 버스 번호가\n") +
+            (Text(L10n.BusVision.Detection.confirmBusNumberPrefix) +
                 Text(recognizedBusNumber)
                 .foregroundColor(Color(.primarynormal))
                 .fontWeight(.bold) +
-                Text("번이 맞나요?")
+                Text(L10n.BusVision.Detection.confirmBusNumber)
             )
             .font(.title)
             .fontWeight(.bold)
@@ -170,7 +170,7 @@ struct SheetView: View {
                         dismiss()
                     }
                 }) {
-                    Text("네, 맞아요.")
+                    Text(L10n.Common.Confirmation.yes)
                         .font(.title2)
                         .fontWeight(.bold)
                         .frame(maxWidth: .infinity)
@@ -186,7 +186,7 @@ struct SheetView: View {
                 Button(action: {
                     viewModel.startListeningProcess()
                 }) {
-                    Text("아니요, 다시 인식할게요")
+                    Text(L10n.BusVision.Detection.retry)
                         .font(.title2)
                         .fontWeight(.bold)
                         .frame(maxWidth: .infinity)
@@ -202,7 +202,7 @@ struct SheetView: View {
                 Button(action: {
                     viewModel.showBusRouteList(routes: busRoutes)
                 }) {
-                    Text("아니요, 목록에서 고를게요")
+                    Text(L10n.BusVision.Detection.selectFromList)
                         .font(.title2)
                         .fontWeight(.bold)
                         .frame(maxWidth: .infinity)


### PR DESCRIPTION
## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
- Closes #161

---

### 🧶 주요 변경 내용 (Summary)
- 프로젝트 전반에 하드코딩된 한국어 문자열을 제거하고, `L10n.swift`와 `Localizable.xcstrings`를 사용한 중앙집중식 문자열 관리로 리팩토링했습니다.
- 이를 통해 다국어(영어) 지원의 기반을 마련하고, 타입 안정성을 확보하며, 일관성 없는 접근성(A11y) 문자열 문제를 해결합니다.

- **`Localizable.xcstrings` (100+ 키 추가)**
  - `bus.arrival.imminent`, `home.a11y.button.mic.label` 등 네임스페이스 기반의 키로 재정의했습니다.
  - 모든 키에 대해 영어(`en`) 번역을 완료했습니다.
  - 사용하지 않는 기존 키(`"%@ 인근"` 등)를 제거했습니다.

- **`L10n.swift` (네임스페이스 구조화)**
  - `Bus`, `BusVision`, `Common`, `Debug`, `Home`, `Permission`, `BusArrival.A11y` 등 네임스페이스를 갖춘 열거형(enum)으로 문자열 구조를 확립했습니다.

- **Presentation Layer 전면 리팩토링**
  - `HomeView`, `SheetView`, `BusArrivalView`, `PermissionSubView`, `BusRouteListView` 등 사용자에게 노출되는 모든 뷰의 하드코딩 문자열을 `L10n` 키로 대체했습니다.
  - `BusArrivalViewModel`의 에러 메시지 등 ViewModel의 문자열도 모두 `L10n`을 사용하도록 수정했습니다.

- **Accessibility(A11y) 문자열 통합**
  - `HomeView`의 마이크 버튼 힌트, `PermissionSubView`의 상태(`거절됨`/`승인됨`), `BusArrivalView`의 실시간 안내 멘트 등 모든 A11y 문자열을 `L10n`으로 이전했습니다.

- **Debug View 개선**
  - `MVPTestView`, `TestView`의 모든 UI 텍스트를 `L10n`으로 이전했습니다.
  - `L10nTestView` (신규): 모든 `L10n` 키를 시각적으로 확인하고 `ko`/`en` 언어 전환을 테스트할 수 있는 디버그 뷰를 추가하고, `DebugView`에 연결했습니다.

---

### 📸 스크린샷 (Optional)


https://github.com/user-attachments/assets/25671602-ba7c-4a61-a999-737cce7803ca



https://github.com/user-attachments/assets/5abaa4dc-75bd-4cf7-8638-038d4b683d54



---

### 🧪 테스트 / 검증 내역
- [x] `L10nTestView`를 통해 `ko` / `en` 모든 문자열 정상 출력 확인
- [x] 앱을 영어 환경으로 변경 후 `HomeView`, `SheetView`, `PermissionSubView` 등 주요 화면에서 영어가 정상적으로 표시되는지 확인
- [x] `BusArrivalView`에서 `String(format:...)`을 사용한 도착 시간/정류장 수 포맷 문자열이 `ko`/`en` 모두 올바르게 조합되는지 확인
- [x] VoiceOver(A11y) 레이블 및 힌트가 `ko`/`en` 환경에 맞게 정상적으로 음성 출력되는지 확인
- [x] `MVPTestView` 및 `TestView`의 디버그 문자열이 `L10n` 키로 정상 출력되는지 확인

---

### 💬 기타 공유 사항
- 앱 전반의 문자열을 다루는 대규모 리팩토링입니다.
- `L10n.swift`의 구조화를 통해 향후 문자열 관리가 용이해질 것으로 기대합니다.

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
- develop에 머지하진 않았으나..! 길버트 리뷰 전 테스트 후 개선사항 리스트 받고자 하여 현 브랜치에서 1.0.2(3)으로 배포하겠습니다!