### PR TITLE
🐛 Fix: #177 BusVision 화면 이탈 후에도 햅틱이 지속되는 문제 해결

### DIFF
--- a/OffStageApp/Sources/Presentation/BusVision/BusDetectionView.swift
+++ b/OffStageApp/Sources/Presentation/BusVision/BusDetectionView.swift
@@ -11,12 +11,13 @@ struct BusDetectionView: UIViewControllerRepresentable {
     let routeNumberToDetect: String
     @Binding var detectStatus: BusDetectStatus
 
-    func makeUIViewController(context _: Context) -> BusDetectionViewController {
+    func makeUIViewController(context: Context) -> BusDetectionViewController {
         let vc = BusDetectionViewController()
         vc.routeNumberToDetect = routeNumberToDetect
-        vc.onDetectedStatusChanged = { status in
+
+        vc.onDetectedStatusChanged = { [weak coordinator = context.coordinator] status in
             DispatchQueue.main.async {
-                detectStatus = status
+                coordinator?.updateStatus(status)
             }
         }
         return vc
@@ -24,5 +25,21 @@ struct BusDetectionView: UIViewControllerRepresentable {
 
     func updateUIViewController(_ uiViewController: BusDetectionViewController, context _: Context) {
         uiViewController.routeNumberToDetect = routeNumberToDetect
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(detectStatus: $detectStatus)
+    }
+
+    class Coordinator: NSObject {
+        @Binding var detectStatus: BusDetectStatus
+
+        init(detectStatus: Binding<BusDetectStatus>) {
+            _detectStatus = detectStatus
+        }
+
+        func updateStatus(_ status: BusDetectStatus) {
+            detectStatus = status
+        }
     }
 }


### PR DESCRIPTION
<!--
🙏 PR 제목 컨벤션 (Gitmoji + 타입 + 이슈 번호 + 작업 요약)
예시: ✨ Feature: #167 예약 취소 구현
※ PR 생성 시 Assignees 및 Labels 설정도 잊지 마세요!
-->

## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
<!-- 해당 PR이 어떤 이슈를 해결하는지 연결해주세요 -->
- Closes #177 

---

### 🧶 주요 변경 내용 (Summary)
<!-- 이번 PR에서 작업한 핵심 변경 사항을 작성해주세요 -->

- 버그 수정: BusVision 화면을 종료해도 햅틱 및 내부 로직이 멈추지 않고 계속 동작
- 순환참조 문제 해결
- onDetectedStatusChanged 클로저가 Binding을 직접 참조하지 않도록 Coordinator 도입

---

### 📸 스크린샷 (Optional)
<!-- UI 작업의 경우, 구현한 화면을 첨부해주세요 -->
<!-- 이미지 크기 조절 예시: <img width="300" alt="설명" src="링크"> -->

<img width="300" alt="예시 이미지" src="https://...">

---

### 🧪 테스트 / 검증 내역
<!-- 동작 확인 여부나 시나리오 테스트 내용을 간단히 써주세요 -->

- [x] 버스비전 화면을 빠져나왔을 때 햅틱이 울리지 않고, 버스도착정보를 출력하는 로그가 더이상 출력되지 않음을 확인

---

### 💬 기타 공유 사항
<!-- 리뷰어가 참고하면 좋을 정보, 고민했던 지점 등을 적어주세요 -->

- 해당 방식의 적절성: 현재는 weak coordinator 약한 고리 하나를 만들어서 강한 참조의 순환 고리를 끊어내는 방식으로 진행했는데요, 더 좋은 방식이 있다면 추천부탁드립니다

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
<!-- 리뷰어가 중점적으로 보면 좋을 포인트가 있다면 알려주세요 -->

