### PR TITLE
✨ Feature: #202 버스 노선 검색 기능 강화 및 VoiceOver 개선

### DIFF
--- a/OffStageApp/Sources/Presentation/Components/BusSearchBar.swift
+++ b/OffStageApp/Sources/Presentation/Components/BusSearchBar.swift
@@ -5,6 +5,7 @@ struct BusSearchBar: View {
     @Binding var text: String
     let showMicButton: Bool
     let isMicEnabled: Bool
+    let micHint: String
     let onSubmit: () -> Void
     let onMicTap: () -> Void
 
@@ -12,18 +13,20 @@ struct BusSearchBar: View {
         text: Binding<String>,
         showMicButton: Bool = true,
         isMicEnabled: Bool = true,
+        micHint: String = "",
         onSubmit: @escaping () -> Void = {},
         onMicTap: @escaping () -> Void = {}
     ) {
         _text = text
         self.showMicButton = showMicButton
         self.isMicEnabled = isMicEnabled
+        self.micHint = micHint
         self.onSubmit = onSubmit
         self.onMicTap = onMicTap
     }
 
     var body: some View {
-        ZStack {
+        HStack(spacing: 0) {
             TextField(
                 "",
                 text: $text,
@@ -38,24 +41,22 @@ struct BusSearchBar: View {
             }
 
             if showMicButton {
-                HStack {
-                    Spacer()
-
-                    Button {
-                        onMicTap()
-                    } label: {
-                        Image(systemName: "mic")
-                            .font(.system(size: 22, weight: .semibold))
-                            .foregroundColor(.white)
-                            .frame(width: 45, height: 45)
-                            .background(
-                                Circle()
-                                    .fill(Color(red: 0.1098, green: 0.1176, blue: 0.1490))
-                            )
-                    }
-                    .disabled(!isMicEnabled)
-                    .opacity(isMicEnabled ? 1.0 : 0.4)
+                Button {
+                    onMicTap()
+                } label: {
+                    Image(systemName: "mic")
+                        .font(.system(size: 22, weight: .semibold))
+                        .foregroundColor(.white)
+                        .frame(width: 45, height: 45)
+                        .background(
+                            Circle()
+                                .fill(Color(red: 0.1098, green: 0.1176, blue: 0.1490))
+                        )
                 }
+                .disabled(!isMicEnabled)
+                .opacity(isMicEnabled ? 1.0 : 0.4)
+                .accessibilityLabel(String(localized: "home.a11y.button.mic.label"))
+                .accessibilityHint(micHint)
                 .padding(.trailing, 10)
             }
         }

--- a/OffStageApp/Sources/Presentation/Home/HomeView.swift
+++ b/OffStageApp/Sources/Presentation/Home/HomeView.swift
@@ -16,6 +16,16 @@ struct HomeView: View {
         UserDefaults.standard.bool(forKey: "hasRequestedPermissions")
     }
 
+    private var micAccessibilityHint: String {
+        if viewModel.isLoading {
+            String(localized: "home.a11y.button.mic.hint.loading")
+        } else if viewModel.nearestBusStop == nil {
+            String(localized: "home.a11y.button.mic.hint.noStop")
+        } else {
+            String(localized: "home.a11y.button.mic.hint.ready")
+        }
+    }
+
     init() {
         _viewModel = StateObject(wrappedValue: HomeViewModel())
     }
@@ -48,6 +58,7 @@ struct HomeView: View {
                 BusSearchBar(
                     text: $busNumberInput,
                     isMicEnabled: !viewModel.isLoading && viewModel.nearestBusStop != nil,
+                    micHint: micAccessibilityHint,
                     onSubmit: {
                         if !busNumberInput.isEmpty, let nearestStop = viewModel.nearestBusStop {
                             router.push(.busRouteSearch(
@@ -185,6 +196,8 @@ struct HomeView: View {
                             .stroke(.white.opacity(0.4), lineWidth: 2)
                     )
                     .cornerRadius(99)
+                    .accessibilityLabel(String(localized: "home.a11y.button.change.label"))
+                    .accessibilityHint(String(localized: "home.a11y.button.change.hint"))
                 }
             }
             .padding()

--- a/OffStageApp/Sources/Presentation/Home/SubView/BusArrivalView.swift
+++ b/OffStageApp/Sources/Presentation/Home/SubView/BusArrivalView.swift
@@ -69,13 +69,6 @@ struct BusArrivalView: View {
 
             Spacer()
             VStack(alignment: .center, spacing: 10) {
-                // Callout/Emphasized
-                Text(L10n.Home.Sheet.busDetectionGuide)
-                    .font(.callout)
-                    .foregroundColor(.white.opacity(0.7))
-                    .multilineTextAlignment(.center)
-                    .padding(.bottom, 5)
-
                 Button(action: {
                     router.push(.busVision(
                         busStop: viewModel.busStop,

--- a/OffStageApp/Sources/Presentation/Search/BusRouteSearchView.swift
+++ b/OffStageApp/Sources/Presentation/Search/BusRouteSearchView.swift
@@ -17,8 +17,8 @@ struct BusRouteSearchView: View {
     @StateObject private var viewModel: BusRouteSearchViewModel
     @Environment(\.dismiss) private var dismiss
     @EnvironmentObject var router: Router<AppRoute>
-    @AccessibilityFocusState private var isTitleFocused: Bool
     @State private var isSheetPresented = false
+    @AccessibilityFocusState private var isSearchBarFocused: Bool
 
     private var currentState: LoadingState {
         if viewModel.isLoading {
@@ -69,6 +69,16 @@ struct BusRouteSearchView: View {
         .onDisappear {
             viewModel.stopAutoRefresh()
         }
+        .onChange(of: viewModel.allBusRoutes) { oldValue, newValue in
+            if !oldValue.isEmpty, !newValue.isEmpty {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                    UIAccessibility.post(
+                        notification: .announcement,
+                        argument: String(localized: "busRouteSearch.a11y.announcement.dataRefreshed")
+                    )
+                }
+            }
+        }
         .sheet(isPresented: $isSheetPresented) {
             SheetView(
                 onTextRecognized: { recognizedText in
@@ -93,6 +103,11 @@ struct BusRouteSearchView: View {
         )
         .padding(.horizontal)
         .padding(.bottom, 30)
+        .accessibilityFocused($isSearchBarFocused)
+        .task {
+            try? await Task.sleep(nanoseconds: 300_000_000)
+            isSearchBarFocused = true
+        }
     }
 
     @ViewBuilder
@@ -112,11 +127,6 @@ struct BusRouteSearchView: View {
     private func busRouteListContent(routes: [BusRouteWithArrival], filterState: FilterState) -> some View {
         VStack(alignment: .leading, spacing: 0) {
             titleText(for: filterState)
-                .accessibilityAddTraits(.isHeader)
-                .accessibilityFocused($isTitleFocused)
-                .onAppear {
-                    isTitleFocused = true
-                }
 
             ScrollView {
                 VStack(spacing: 0) {
@@ -156,6 +166,8 @@ struct BusRouteSearchView: View {
                     )
             }
             .padding(.horizontal, 40)
+            .accessibilityLabel(String(localized: "busRouteSearch.a11y.button.quickRecognition.label"))
+            .accessibilityHint(String(localized: "busRouteSearch.a11y.button.quickRecognition.hint"))
         }
         .padding(.bottom, 40)
     }
@@ -226,6 +238,7 @@ struct BusRouteSearchView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(PlainButtonStyle())
+        .accessibilityHint(String(localized: "busRouteSearch.a11y.row.hint"))
     }
 
     @ViewBuilder


### PR DESCRIPTION
## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
- Closes #202 

---

### 🧶 주요 변경 내용 (Summary)
- **1. 버스 노선 검색 필터링 기능 추가** (0b709d2)
  - `BusRouteSearchViewModel`에 전체 노선 목록(`allBusRoutes`)을 저장하고, 검색어(`recognizedText`)에 따라 실시간으로 필터링하는 로직을 구현했습니다.
  - 검색 결과 유무에 따라 안내 문구와 '버스 바로 인식' 버튼을 표시하는 UI(`searchPromptFooter`)를 추가했습니다.

- **2. BusSearchBar 컴포넌트 분리 및 재사용** (ecf54fd)
  - `HomeView`와 `BusRouteSearchView`에서 중복되던 검색바(텍스트 필드 + 마이크 버튼)를 `BusSearchBar` 공통 컴포넌트로 분리했습니다.
  - 힌트 텍스트(`micHint`), 마이크 활성화 여부(`isMicEnabled`) 등을 주입받아 유연하게 사용할 수 있도록 개선했습니다.

- **3. SheetView 리팩토링 (STT 전용)** (73cea25)
  - `SheetView`의 역할을 **음성 인식(STT)** 기능 하나로 축소했습니다.
  - 기존의 결과 목록 표시 및 확인 로직을 제거하고, 인식 완료 시 텍스트만 반환하고 종료되도록 단순화했습니다. 결과 처리는 이제 `BusRouteSearchView`가 전담합니다.

- **4. VoiceOver 접근성 개선** (e739994)
  - **검색창 초기 포커스**: `BusRouteSearchView` 진입 시 검색창(`BusSearchBar`)에 자동으로 포커스가 이동하도록 `.accessibilityFocused`를 적용했습니다.
  - **데이터 갱신 안내**: 데이터 자동 갱신 시 시각장애 사용자가 인지할 수 있도록 `UIAccessibility.post(.announcement)`로 갱신 멘트를 방송합니다.
  - **명확한 레이블/힌트**: '버스 바로 인식' 버튼과 리스트 항목에 대한 접근성 레이블 및 힌트를 보강했습니다.

---

### 📸 스크린샷 (Optional)
*(개선된 검색 화면 및 필터링 동작)*

---

### 🧪 테스트 / 검증 내역
- [x] 홈 화면에서 검색어 입력 및 마이크 버튼 동작 확인 (컴포넌트 분리 영향도 점검)
- [x] 검색 화면에서 검색어 입력 시 리스트가 실시간으로 필터링되는지 확인
- [x] 검색 결과가 없을 때 안내 문구와 '버스 바로 인식' 버튼 노출 확인
- [x] **VoiceOver**: 검색 화면 진입 시 검색창으로 포커스가 자동 이동하는지 확인
- [x] **VoiceOver**: 데이터 갱신 시 "도착 정보가 갱신되었습니다" 음성 안내 확인

---

### 💬 기타 공유 사항
> [!NOTE]  
> **후속 작업 필요:** 현재 Native 키패드를 사용하는 곳(`BusSearchBar` 등)에서 키패드 외부 영역을 터치했을 때 키패드가 내려가는 처리가 추가되어야 합니다. 추후 이슈로 등록하여 처리할 예정입니다.

---

### 🙇🏻‍♀️ 리뷰 가이드 (선택)
- `BusRouteSearchViewModel`의 필터링 로직(`filterBusRoutes`)과 `allBusRoutes` 관리 방식
- `BusSearchBar` 컴포넌트의 재사용 구조 및 접근성 속성 적용
- `BusRouteSearchView`의 VoiceOver 포커스 제어 로직 (`.task` 활용 부분)