### PR TITLE
✨ Feature: #247 버스 인식 화면 이동 시 중복 탭 방지

### DIFF
--- a/OffStageApp/Sources/Presentation/Home/SubView/BusArrivalView.swift
+++ b/OffStageApp/Sources/Presentation/Home/SubView/BusArrivalView.swift
@@ -75,10 +75,12 @@ struct BusArrivalView: View {
                 }
 
                 Button(action: {
-                    router.push(.busVision(
-                        busStop: viewModel.busStop,
-                        busRoute: viewModel.busRoute
-                    ))
+                    if let params = viewModel.navigateToBusVision() {
+                        router.push(.busVision(
+                            busStop: params.busStop,
+                            busRoute: params.busRoute
+                        ))
+                    }
                 }) {
                     HStack {
                         Image(systemName: "camera")
@@ -93,6 +95,8 @@ struct BusArrivalView: View {
                     .padding(.horizontal, 2)
                     .frame(maxWidth: .infinity)
                 }
+                .disabled(viewModel.isNavigating)
+                .opacity(viewModel.isNavigating ? 0.5 : 1.0)
                 .overlay(
                     RoundedRectangle(cornerRadius: 99)
                         .stroke(Color(.primarynormal), lineWidth: 6)

--- a/OffStageApp/Sources/Presentation/Home/SubView/BusArrivalViewModel.swift
+++ b/OffStageApp/Sources/Presentation/Home/SubView/BusArrivalViewModel.swift
@@ -13,6 +13,7 @@ final class BusArrivalViewModel: ObservableObject {
     @Published var isLoading = false
     @Published var errorMessage: String?
     @Published var currentEstimatedArrivalTime: Int?
+    @Published var isNavigating = false
 
     // MARK: - 속성
 
@@ -74,6 +75,18 @@ final class BusArrivalViewModel: ObservableObject {
         arrivalMonitoringTask = nil
         stopCountdownTimer()
         hasVibratedAtSecondStop = false
+    }
+
+    func navigateToBusVision() -> (busStop: BusStop, busRoute: BusRoute)? {
+        guard !isNavigating else { return nil }
+        isNavigating = true
+
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 2_000_000_000)
+            isNavigating = false
+        }
+
+        return (busStop, busRoute)
     }
 
     // MARK: - 비공개 헬퍼 메서드

--- a/Project.swift
+++ b/Project.swift
@@ -9,7 +9,7 @@ let baseInfoPlist: [String: Plist.Value] = [
         "UIImageName": "",
     ],
     "CFBundleShortVersionString": "1.0.4",
-    "CFBundleVersion": "1",
+    "CFBundleVersion": "2",
     "ARRIVAL_SERVICE_KEY": "$(ARRIVAL_SERVICE_KEY)",
     "LOCATION_SERVICE_KEY": "$(LOCATION_SERVICE_KEY)",
     "STOP_SERVICE_KEY": "$(STOP_SERVICE_KEY)",


### PR DESCRIPTION
## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
- Closes #247

---

### 🧶 주요 변경 내용 (Summary)
- **중복 네비게이션 방지**:
  - `BusArrivalViewModel`에 `isNavigating` 상태를 추가하여, 화면 전환이 시작되면 버튼을 일시적으로 비활성화합니다.
  - `MapsToBusVision()` 메서드를 통해 네비게이션 파라미터를 안전하게 반환받고, 중복 호출을 차단합니다.
  - 버튼 비활성화 시 불투명도를 0.5로 낮추어 사용자에게 피드백을 제공합니다.
  
- **빌드 버전 업데이트**:
  - `Project.swift`의 `CFBundleVersion`을 2로 올렸습니다.

---

### 🧪 테스트 / 검증 내역
- [x] '버스 인식하기' 버튼을 빠르게 연속으로 탭했을 때 `BusVisionView`가 한 번만 열리는지 확인
- [x] 네비게이션 후 돌아왔을 때(또는 2초 후) 버튼이 다시 활성화되는지 확인
- [x] 빌드 버전이 2로 정상적으로 적용되었는지 확인

---

### 💬 기타 공유 사항
- `isNavigating` 상태는 2초 후 자동으로 `false`로 리셋되도록 안전 장치를 두었습니다. (`Task.sleep` 사용)
