### PR TITLE
✨ Feature: #249 버스 인식 화면 이동 시 중복 탭 방지

### DIFF
--- a/Modules/BusAPI/Sources/Repositories/MainBusRepository.swift
+++ b/Modules/BusAPI/Sources/Repositories/MainBusRepository.swift
@@ -9,11 +9,19 @@ public final class MainBusRepository: BusRepository {
     private lazy var realSeoulRepository = SeoulBusRepository()
 
     private var tagoRepository: BusRepository {
-        shouldUseMock ? mockRepository : realTagoRepository
+        #if DEBUG_MODE
+            shouldUseMock ? mockRepository : realTagoRepository
+        #else
+            realTagoRepository
+        #endif
     }
 
     private var seoulRepository: BusRepository {
-        shouldUseMock ? mockRepository : realSeoulRepository
+        #if DEBUG_MODE
+            shouldUseMock ? mockRepository : realSeoulRepository
+        #else
+            realSeoulRepository
+        #endif
     }
 
     public init() {}

--- a/Modules/BusAPI/Sources/Repositories/MainBusRepository.swift
+++ b/Modules/BusAPI/Sources/Repositories/MainBusRepository.swift
@@ -2,18 +2,28 @@ import BusAPI
 import Foundation
 
 public final class MainBusRepository: BusRepository {
+    #if DEBUG_MODE
+        private let mockRepository = MockBusRepository()
+    #endif
+    private lazy var realTagoRepository = TagoBusRepository()
+    private lazy var realSeoulRepository = SeoulBusRepository()
+
     private var tagoRepository: BusRepository {
-        shouldUseMock() ? MockBusRepository() : TagoBusRepository()
+        shouldUseMock ? mockRepository : realTagoRepository
     }
 
     private var seoulRepository: BusRepository {
-        shouldUseMock() ? MockBusRepository() : SeoulBusRepository()
+        shouldUseMock ? mockRepository : realSeoulRepository
     }
 
     public init() {}
 
-    private func shouldUseMock() -> Bool {
-        UserDefaults.standard.bool(forKey: "useMockData")
+    private var shouldUseMock: Bool {
+        #if DEBUG_MODE
+            UserDefaults.standard.bool(forKey: "useMockData")
+        #else
+            false
+        #endif
     }
 
     // MARK: - BusRepository conformance
@@ -27,62 +37,42 @@ public final class MainBusRepository: BusRepository {
     }
 
     public func searchStops(cityCode: String?, nodeName: String?, nodeNumber: String?) async throws -> [BusStop] {
-        if cityCode == "1000" {
-            return try await seoulRepository.searchStops(cityCode: cityCode, nodeName: nodeName, nodeNumber: nodeNumber)
-        }
-        return try await tagoRepository.searchStops(cityCode: cityCode, nodeName: nodeName, nodeNumber: nodeNumber)
+        let repository = cityCode == "1000" ? seoulRepository : tagoRepository
+        return try await repository.searchStops(cityCode: cityCode, nodeName: nodeName, nodeNumber: nodeNumber)
     }
 
     public func fetchStopsNearby(latitude: Double, longitude: Double, cityCode: String?) async throws -> [BusStop] {
-        if cityCode == "1000" {
-            return try await seoulRepository.fetchStopsNearby(
-                latitude: latitude,
-                longitude: longitude,
-                cityCode: cityCode
-            )
-        }
-        return try await tagoRepository.fetchStopsNearby(latitude: latitude, longitude: longitude, cityCode: cityCode)
+        let repository = cityCode == "1000" ? seoulRepository : tagoRepository
+        return try await repository.fetchStopsNearby(latitude: latitude, longitude: longitude, cityCode: cityCode)
     }
 
     public func fetchRoutesPassingThroughStop(cityCode: String, nodeId: String) async throws -> [BusRoute] {
-        if cityCode == "1000" {
-            return try await seoulRepository.fetchRoutesPassingThroughStop(cityCode: cityCode, nodeId: nodeId)
-        }
-        return try await tagoRepository.fetchRoutesPassingThroughStop(cityCode: cityCode, nodeId: nodeId)
+        let repository = cityCode == "1000" ? seoulRepository : tagoRepository
+        return try await repository.fetchRoutesPassingThroughStop(cityCode: cityCode, nodeId: nodeId)
     }
 
     public func fetchRouteInfo(cityCode: String, routeId: String) async throws -> BusRoute? {
-        if cityCode == "1000" {
-            return try await seoulRepository.fetchRouteInfo(cityCode: cityCode, routeId: routeId)
-        }
-        return try await tagoRepository.fetchRouteInfo(cityCode: cityCode, routeId: routeId)
+        let repository = cityCode == "1000" ? seoulRepository : tagoRepository
+        return try await repository.fetchRouteInfo(cityCode: cityCode, routeId: routeId)
     }
 
     public func searchRoutes(cityCode: String, routeNumber: String) async throws -> [BusRoute] {
-        if cityCode == "1000" {
-            return try await seoulRepository.searchRoutes(cityCode: cityCode, routeNumber: routeNumber)
-        }
-        return try await tagoRepository.searchRoutes(cityCode: cityCode, routeNumber: routeNumber)
+        let repository = cityCode == "1000" ? seoulRepository : tagoRepository
+        return try await repository.searchRoutes(cityCode: cityCode, routeNumber: routeNumber)
     }
 
     public func fetchRouteStations(cityCode: String, routeId: String) async throws -> [BusRouteStation] {
-        if cityCode == "1000" {
-            return try await seoulRepository.fetchRouteStations(cityCode: cityCode, routeId: routeId)
-        }
-        return try await tagoRepository.fetchRouteStations(cityCode: cityCode, routeId: routeId)
+        let repository = cityCode == "1000" ? seoulRepository : tagoRepository
+        return try await repository.fetchRouteStations(cityCode: cityCode, routeId: routeId)
     }
 
     public func fetchStopArrivals(cityCode: String, nodeId: String) async throws -> [BusArrival] {
-        if cityCode == "1000" {
-            return try await seoulRepository.fetchStopArrivals(cityCode: cityCode, nodeId: nodeId)
-        }
-        return try await tagoRepository.fetchStopArrivals(cityCode: cityCode, nodeId: nodeId)
+        let repository = cityCode == "1000" ? seoulRepository : tagoRepository
+        return try await repository.fetchStopArrivals(cityCode: cityCode, nodeId: nodeId)
     }
 
     public func fetchRouteArrivals(cityCode: String, nodeId: String, routeId: String) async throws -> [BusArrival] {
-        if cityCode == "1000" {
-            return try await seoulRepository.fetchRouteArrivals(cityCode: cityCode, nodeId: nodeId, routeId: routeId)
-        }
-        return try await tagoRepository.fetchRouteArrivals(cityCode: cityCode, nodeId: nodeId, routeId: routeId)
+        let repository = cityCode == "1000" ? seoulRepository : tagoRepository
+        return try await repository.fetchRouteArrivals(cityCode: cityCode, nodeId: nodeId, routeId: routeId)
     }
 }

--- a/OffStageApp/Sources/Infrastructure/LocationManager.swift
+++ b/OffStageApp/Sources/Infrastructure/LocationManager.swift
@@ -1,6 +1,7 @@
 import Combine
 import CoreLocation
 import Foundation
+import MapKit
 
 /// A concrete implementation of the `LocationProviding` protocol using Apple's CoreLocation framework.
 ///
@@ -54,6 +55,10 @@ final class LocationManager: NSObject, LocationProviding {
             if isOverrideEnabled, let overrideLocation {
                 return overrideLocation
             }
+
+            if shouldUseMockData {
+                return mockC5Location
+            }
         #endif
 
         return try await withCheckedThrowingContinuation { continuation in
@@ -62,20 +67,39 @@ final class LocationManager: NSObject, LocationProviding {
         }
     }
 
-    // [추가] 프로토콜 함수 구현
-    func fetchPlacemark(from location: CLLocationCoordinate2D) async throws -> CLPlacemark? {
-        let clLocation = CLLocation(
-            latitude: location.latitude,
-            longitude: location.longitude
-        )
+    #if DEBUG_MODE
+        private var shouldUseMockData: Bool {
+            UserDefaults.standard.bool(forKey: "useMockData")
+        }
 
-        // 로케일을 "ko-KR"로 설정하여 주소를 한국어로 받습니다.
+        private var mockC5Location: CLLocationCoordinate2D {
+            CLLocationCoordinate2D(latitude: 36.0143, longitude: 129.3256)
+        }
+    #endif
+
+    func fetchPlacemark(from location: CLLocationCoordinate2D) async throws -> CLPlacemark? {
+        #if DEBUG_MODE
+            if shouldUseMockData {
+                return mockC5Placemark(for: location)
+            }
+        #endif
+
+        let clLocation = CLLocation(latitude: location.latitude, longitude: location.longitude)
         let placemarks = try await geocoder.reverseGeocodeLocation(
             clLocation,
             preferredLocale: Locale(identifier: "ko-KR")
         )
         return placemarks.first
     }
+
+    #if DEBUG_MODE
+        private func mockC5Placemark(for location: CLLocationCoordinate2D) -> CLPlacemark {
+            MKPlacemark(coordinate: location, addressDictionary: [
+                "City": "포항시",
+                "State": "경상북도",
+            ])
+        }
+    #endif
 }
 
 // MARK: - CLLocationManagerDelegate

--- a/Project.swift
+++ b/Project.swift
@@ -9,7 +9,7 @@ let baseInfoPlist: [String: Plist.Value] = [
         "UIImageName": "",
     ],
     "CFBundleShortVersionString": "1.0.4",
-    "CFBundleVersion": "2",
+    "CFBundleVersion": "3",
     "ARRIVAL_SERVICE_KEY": "$(ARRIVAL_SERVICE_KEY)",
     "LOCATION_SERVICE_KEY": "$(LOCATION_SERVICE_KEY)",
     "STOP_SERVICE_KEY": "$(STOP_SERVICE_KEY)",


### PR DESCRIPTION
## ✨ What’s this PR?
### 📌 관련 이슈 (Related Issue)
- Closes #249

---

### 🧶 주요 변경 내용 (Summary)
- **중복 네비게이션 방지**:
  - `BusArrivalViewModel`에 `isNavigating` 상태를 추가하여, 화면 전환이 시작되면 버튼을 일시적으로 비활성화합니다.
  - `MapsToBusVision()` 메서드를 통해 네비게이션 파라미터를 안전하게 반환받고, 중복 호출을 차단합니다.
  - 버튼 비활성화 시 불투명도를 0.5로 낮추어 사용자에게 피드백을 제공합니다.
  
- **빌드 버전 업데이트**:
  - `Project.swift`의 `CFBundleVersion`을 2로 올렸습니다.

---

### 🧪 테스트 / 검증 내역
- [x] '버스 인식하기' 버튼을 빠르게 연속으로 탭했을 때 `BusVisionView`가 한 번만 열리는지 확인
- [x] 네비게이션 후 돌아왔을 때(또는 2초 후) 버튼이 다시 활성화되는지 확인
- [x] 빌드 버전이 2로 정상적으로 적용되었는지 확인

---

### 💬 기타 공유 사항
- `isNavigating` 상태는 2초 후 자동으로 `false`로 리셋되도록 안전 장치를 두었습니다. (`Task.sleep` 사용)